### PR TITLE
[JavaScript] reduce generated code size

### DIFF
--- a/javascript/benchmark/draw.py
+++ b/javascript/benchmark/draw.py
@@ -19,7 +19,7 @@ rects2 = ax.bar(x, protobuf, width, label='protobuf')
 rects3 = ax.bar(x + width, fury, width, label='fury', color="#7845FD")
 
 # Add some text for labels, title and custom x-axis tick labels, etc.
-ax.set_ylabel('Tps')
+ax.set_ylabel('Tps/10000')
 ax.set_title('javascript complex object', loc="center")
 ax.set_xticks(x)
 ax.set_xticklabels(labels)

--- a/javascript/packages/fury/lib/classResolver.ts
+++ b/javascript/packages/fury/lib/classResolver.ts
@@ -6,7 +6,7 @@ import mapSerializer from "./internalSerializer/map";
 import setSerializer from "./internalSerializer/set";
 import boolSerializer from "./internalSerializer/bool";
 import { uInt16Serializer, int16Serializer, int32Serializer, uInt32Serializer, uInt64Serializer, floatSerializer, doubleSerializer, uInt8Serializer, int64Serializer, int8Serializer } from "./internalSerializer/number";
-import { InternalSerializerType, Serializer, SerializerRead, SerializerWrite, Fury, BinaryReader, BinaryWriter } from "./type";
+import { InternalSerializerType, Serializer, SerializerRead, SerializerWrite, Fury, BinaryReader, BinaryWriter, SerializerConfig } from "./type";
 
 
 const USESTRINGVALUE = 0;
@@ -82,7 +82,7 @@ export default class SerializerResolver {
             this.customSerializer[tag] = {
                 read: unreachable,
                 write: unreachable,
-                reserveWhenWrite: unreachable,
+                config: unreachable,
             }
         }
         const exists = this.customSerializer[tag];
@@ -92,12 +92,12 @@ export default class SerializerResolver {
         exists.read = serializer;
     }
 
-    registerWriteSerializerByTag(tag: string, serializer: SerializerWrite) {
+    registerWriteSerializerByTag(tag: string, serializer: SerializerWrite, config: ReturnType<SerializerConfig>) {
         if (!this.customSerializer[tag]) {
             this.customSerializer[tag] = {
                 read: unreachable,
                 write: unreachable,
-                reserveWhenWrite: unreachable,
+                config: unreachable,
             }
         }
         const exists = this.customSerializer[tag];
@@ -105,6 +105,9 @@ export default class SerializerResolver {
             throw new Error(`${tag} write has been registered`);
         }
         exists.write = serializer;
+        exists.config = () => {
+            return config;
+        }
     }
 
     existsTagReadSerializer(tag: string) {

--- a/javascript/packages/fury/lib/internalSerializer/array.ts
+++ b/javascript/packages/fury/lib/internalSerializer/array.ts
@@ -8,8 +8,8 @@ import { int8Serializer, int32Serializer, int64Serializer, floatSerializer, doub
 const buildTypedArray = <T>(fury: Fury, read: () => void,  write: (p: T) => void) => {
     const serializer = arraySerializer(fury);
     return {
-        read: (shouldSetRef: boolean) => {
-            const result =  serializer.read(shouldSetRef)
+        read: () => {
+            const result =  serializer.read()
             for (let i = 0 ;i < result.length; i++) {
                 result[i] = read();
             }
@@ -21,7 +21,7 @@ const buildTypedArray = <T>(fury: Fury, read: () => void,  write: (p: T) => void
                 write(item);
             }
         },
-        reserveWhenWrite: serializer.reserveWhenWrite,
+        config: serializer.config,
     } as Serializer<T[]>
 }
 
@@ -113,12 +113,10 @@ export const arraySerializer = (fury: Fury) => {
     const { writeInt8, writeInt16, writeInt32 } = binaryWriter;
     const { readInt32 } = binaryView;
     return {
-        read: (shouldSetRef: boolean) => {
+        read: () => {
             const len = readInt32();
             const result = new Array(len);
-            if (shouldSetRef) {
-                pushReadObject(result);
-            }
+            pushReadObject(result);
             return result;
         },
         write: (v: any[]) => {
@@ -130,8 +128,11 @@ export const arraySerializer = (fury: Fury) => {
             pushWriteObject(v);
             writeInt32(v.length);
         },
-        reserveWhenWrite: () => {
-            return 7; 
+        config: () => {
+            return {
+                reserve: 7,
+                refType: true,
+            }
         }
     }
 }

--- a/javascript/packages/fury/lib/internalSerializer/binary.ts
+++ b/javascript/packages/fury/lib/internalSerializer/binary.ts
@@ -9,13 +9,11 @@ export default (fury: Fury) => {
     const { pushReadObject, pushWriteObject } = referenceResolver;
     
     return {
-        read: (shouldSetRef: boolean) => {
+        read: () => {
             readUInt8(); // isInBand
             const len = readInt32();
             const result = readBuffer(len);
-            if (shouldSetRef) {
-                pushReadObject(result);
-            }
+            pushReadObject(result);
             return result
         },
         write: (v: Uint8Array) => {
@@ -29,8 +27,11 @@ export default (fury: Fury) => {
             writeInt32(v.byteLength);
             writeBuffer(v);
         },
-        reserveWhenWrite: () => {
-            return 8; 
+        config: () => {
+            return {
+                reserve: 8,
+                refType: true,
+            }
         }
     }
 }

--- a/javascript/packages/fury/lib/internalSerializer/bool.ts
+++ b/javascript/packages/fury/lib/internalSerializer/bool.ts
@@ -15,8 +15,10 @@ export default (fury: Fury) => {
             writeInt16(InternalSerializerType.BOOL);
             writeUInt8(v ? 1 : 0)
         },
-        reserveWhenWrite: () => {
-            return 4; 
+        config: () => {
+            return {
+                reserve: 4,
+            }
         }
     }
 }

--- a/javascript/packages/fury/lib/internalSerializer/datetime.ts
+++ b/javascript/packages/fury/lib/internalSerializer/datetime.ts
@@ -16,8 +16,10 @@ export const timestampSerializer = (fury: Fury) => {
             writeInt16(InternalSerializerType.TIMESTAMP);
             writeInt64(BigInt(v.getTime()));
         },
-        reserveWhenWrite: () => {
-            return 11; 
+        config: () => {
+            return {
+                reserve: 11
+            }
         }
     }
 }
@@ -38,8 +40,10 @@ export const dateSerializer = (fury: Fury) => {
             writeInt16(InternalSerializerType.DATE);
             writeInt32(day);
         },
-        reserveWhenWrite: () => {
-            return 7; 
+        config: () => {
+            return {
+                reserve: 7,
+            }
         }
     }
 }

--- a/javascript/packages/fury/lib/internalSerializer/map.ts
+++ b/javascript/packages/fury/lib/internalSerializer/map.ts
@@ -9,12 +9,10 @@ export default (fury: Fury) => {
     const { pushReadObject, pushWriteObject } = referenceResolver;
 
     return {
-        read: (shouldSetRef: boolean) => {
+        read: () => {
             const len = readUInt32();
             const result = new Map();
-            if (shouldSetRef) {
-                pushReadObject(result);
-            }
+            pushReadObject(result);
             for (let index = 0; index < len; index++) {
                 const key = read();
                 const value = read();
@@ -36,8 +34,11 @@ export default (fury: Fury) => {
                 write(value);
             }
         },
-        reserveWhenWrite: () => {
-            return 7; 
+        config: () => {
+            return {
+                reserve: 7,
+                refType: true,
+            }
         }
     }
 }

--- a/javascript/packages/fury/lib/internalSerializer/number.ts
+++ b/javascript/packages/fury/lib/internalSerializer/number.ts
@@ -14,8 +14,10 @@ export const uInt8Serializer = (fury: Fury) => {
             writeInt16(InternalSerializerType.UINT8);
             writeUInt8(v);
         },
-        reserveWhenWrite: () => {
-            return 4; 
+        config: () => {
+            return {
+                reserve: 4,
+            }
         }
     };
 };
@@ -34,8 +36,10 @@ export const floatSerializer = (fury: Fury) => {
             writeInt16(InternalSerializerType.FLOAT);
             writeFloat(v);
         },
-        reserveWhenWrite: () => {
-            return 7; 
+        config: () => {
+            return {
+                reserve: 7,
+            }
         }
     };
 };
@@ -54,8 +58,10 @@ export const doubleSerializer = (fury: Fury) => {
             writeInt16(InternalSerializerType.DOUBLE);
             writeDouble(v);
         },
-        reserveWhenWrite: () => {
-            return 11; 
+        config: () => {
+            return {
+                reserve: 11,
+            }
         }
     };
 };
@@ -74,8 +80,10 @@ export const int8Serializer = (fury: Fury) => {
             writeInt16(InternalSerializerType.INT8);
             writeInt8(v);
         },
-        reserveWhenWrite: () => {
-            return 4; 
+        config: () => {
+            return {
+                reserve: 4,
+            }
         }
     };
 };
@@ -94,8 +102,10 @@ export const uInt16Serializer = (fury: Fury) => {
             writeInt16(InternalSerializerType.UINT16);
             writeUInt16(v);
         },
-        reserveWhenWrite: () => {
-            return 5; 
+        config: () => {
+            return {
+                reserve: 5,
+            }
         }
     };
 };
@@ -114,8 +124,10 @@ export const int16Serializer = (fury: Fury) => {
             writeInt16(InternalSerializerType.INT16);
             writeInt16(v);
         },
-        reserveWhenWrite: () => {
-            return 5; 
+        config: () => {
+            return {
+                reserve: 5,
+            }
         }
     };
 };
@@ -134,8 +146,10 @@ export const uInt32Serializer = (fury: Fury) => {
             writeInt16(InternalSerializerType.UINT32);
             writeUInt32(v);
         },
-        reserveWhenWrite: () => {
-            return 7; 
+        config: () => {
+            return {
+                reserve: 7,
+            }
         }
     };
 };
@@ -154,8 +168,10 @@ export const int32Serializer = (fury: Fury) => {
             writeInt16(InternalSerializerType.INT32);
             writeInt32(v);
         },
-        reserveWhenWrite: () => {
-            return 7; 
+        config: () => {
+            return {
+                reserve: 7,
+            }
         }
     };
 };
@@ -174,8 +190,10 @@ export const uInt64Serializer = (fury: Fury) => {
             writeInt16(InternalSerializerType.UINT64);
             writeUInt64(v);
         },
-        reserveWhenWrite: () => {
-            return 11; 
+        config: () => {
+            return {
+                reserve: 11,
+            }
         }
     };
 };
@@ -194,8 +212,10 @@ export const int64Serializer = (fury: Fury) => {
             writeInt16(InternalSerializerType.INT64);
             writeInt64(v);
         },
-        reserveWhenWrite: () => {
-            return 11; 
+        config: () => {
+            return {
+                reserve: 11,
+            }
         }
     };
 };

--- a/javascript/packages/fury/lib/internalSerializer/set.ts
+++ b/javascript/packages/fury/lib/internalSerializer/set.ts
@@ -9,12 +9,10 @@ export default (fury: Fury) => {
 
     const { pushReadObject, pushWriteObject } = referenceResolver;
     return {
-        read: (shouldSetRef: boolean) => {
+        read: () => {
             const len = readUInt32();
             const result = new Set();
-            if (shouldSetRef) {
-                pushReadObject(result);
-            }
+            pushReadObject(result);
             for (let index = 0; index < len; index++) {
                 result.add(read());
             }
@@ -33,8 +31,11 @@ export default (fury: Fury) => {
                 write(value);
             }
         },
-        reserveWhenWrite: () => {
-            return 7; 
+        config: () => {
+            return {
+                reserve: 7,
+                refType: true,
+            }
         }
     }
 }

--- a/javascript/packages/fury/lib/internalSerializer/string.ts
+++ b/javascript/packages/fury/lib/internalSerializer/string.ts
@@ -7,23 +7,19 @@ export default (fury: Fury) => {
     const { binaryView, binaryWriter, writeNull, referenceResolver } = fury;
     const { writeInt8, writeInt16, writeStringOfVarInt32 } = binaryWriter
     const { readVarInt32, readStringUtf8, readUInt8, readStringLatin1 } = binaryView;
-    const { pushReadObject } = referenceResolver;
 
     return {
-        read: (shouldSetRef: boolean) => {
+        read: () => {
             const type = readUInt8();
             const len = readVarInt32();
             const result = type === LATIN1 ? readStringLatin1(len) : readStringUtf8(len);
-            if (shouldSetRef) {
-                pushReadObject(result);
-            }
             return result;
         },
         write: (v: string) => {
             if (writeNull(v)) {
                 return;
             }
-            writeInt8(RefFlags.RefValueFlag);
+            writeInt8(RefFlags.NotNullValueFlag);
             writeInt16(InternalSerializerType.STRING);
             writeStringOfVarInt32(v);
         },
@@ -31,11 +27,13 @@ export default (fury: Fury) => {
             if (writeNull(v)) {
                 return;
             }
-            writeInt8(RefFlags.RefValueFlag);
+            writeInt8(RefFlags.NotNullValueFlag);
             writeStringOfVarInt32(v);
         },
-        reserveWhenWrite: () => {
-            return 7; 
+        config: () => {
+            return {
+                reserve: 7,
+            }
         }
     }
 }

--- a/javascript/packages/fury/lib/type.ts
+++ b/javascript/packages/fury/lib/type.ts
@@ -47,18 +47,24 @@ export enum ConfigFlags {
 }
 
 export type SerializerRead<T = any> = (
-	shouldSetRef: boolean,
 ) => T
 
 export type SerializerWrite<T = any> = (
 	v: T,
 ) => void
 
+export type SerializerConfig = (
+) => {
+	reserve: number,
+	refType?: boolean,
+}
+
+
 // read, write
 export type Serializer<T = any, T2 = any> = {
 	read: SerializerRead<T2>, 
 	write: SerializerWrite<T>,
-	reserveWhenWrite: () => number,
+	config: SerializerConfig,
 };
 
 

--- a/javascript/test/array.test.ts
+++ b/javascript/test/array.test.ts
@@ -1,13 +1,19 @@
-import Fury, { TypeDescription, InternalSerializerType, ObjectTypeDescription } from '@furyjs/fury';
+import Fury, { TypeDescription, InternalSerializerType, ObjectTypeDescription, Type } from '@furyjs/fury';
 import { describe, expect, test } from '@jest/globals';
 
 describe('array', () => {
   test('should array work', () => {
     const hps = process.env.enableHps ? require('@furyjs/hps') : null;
-    const fury = new Fury({ hps }); const result = fury.deserialize(
-      Buffer.from([6, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 1, 2, 0, 0, 0, 0, 0, 4, 115, 116, 114, 49, 254, 1])
-    );
-    expect(result).toEqual(["str1", "str1"])
+
+    const description = Type.object("example.bar", {
+      c: Type.array(Type.object("example.foo", {
+        a: Type.string()
+      }))
+    });
+    const fury = new Fury({ hps });
+    const { serialize, deserialize } = fury.registerSerializer(description);
+    const o = { a: "123" };
+    expect(deserialize(serialize({ c: [o, o] }))).toEqual({ c: [o, o] })
   });
   test('should typedarray work', () => {
     const description = {
@@ -37,7 +43,7 @@ describe('array', () => {
       }
     };
     const hps = process.env.enableHps ? require('@furyjs/hps') : null;
-  const fury = new Fury({ hps }); const serializer = fury.registerSerializer(description).serializer;
+    const fury = new Fury({ hps }); const serializer = fury.registerSerializer(description).serializer;
     const input = fury.serialize({
       a: [true, false],
       a2: [1, 2, 3],


### PR DESCRIPTION
## What do these changes do?
currently, we generate switch statements for each type,  which results in long generated code. Therefore we are replacing the switch statements  with closure. This will reduce generated code size without sacrificing performance.

## Related issue number
Closes #632 
