### PR TITLE
[Java] Fix  IndexOutOfBoundsException when new fury deserialize from InputStream

### DIFF
--- a/java/fury-core/src/main/java/io/fury/Fury.java
+++ b/java/fury-core/src/main/java/io/fury/Fury.java
@@ -691,6 +691,7 @@ public final class Fury {
       int read = inputStream.read(buffer.getHeapMemory(), 0, 4);
       Preconditions.checkArgument(read == 4);
       int size = buffer.readInt();
+      buffer.ensure(size + 4);
       read = inputStream.read(buffer.getHeapMemory(), 4, size);
       Preconditions.checkArgument(read == size);
       return deserialize(buffer, outOfBandBuffers);
@@ -1109,6 +1110,7 @@ public final class Fury {
         int read = inputStream.read(buffer.getHeapMemory(), 0, 4);
         Preconditions.checkArgument(read == 4);
         int size = buffer.readInt();
+        buffer.ensure(4 + size);
         read = inputStream.read(buffer.getHeapMemory(), 4, size);
         Preconditions.checkArgument(read == size);
       }

--- a/java/fury-core/src/test/java/io/fury/FuryTest.java
+++ b/java/fury-core/src/test/java/io/fury/FuryTest.java
@@ -438,6 +438,14 @@ public class FuryTest extends FuryTestBase {
     assertEquals(newObj, beanA);
     newObj = fury.deserialize(bis);
     assertEquals(newObj, beanA);
+
+    fury = Fury.builder().requireClassRegistration(false).build();
+    // test reader buffer grow
+    bis = new ByteArrayInputStream(bas.toByteArray());
+    newObj = fury.deserialize(bis);
+    assertEquals(newObj, beanA);
+    newObj = fury.deserialize(bis);
+    assertEquals(newObj, beanA);
   }
 
   @Test
@@ -462,6 +470,14 @@ public class FuryTest extends FuryTestBase {
       bas.flush();
       ByteArrayInputStream bis = new ByteArrayInputStream(bas.toByteArray());
       Object newObj = fury.deserializeJavaObjectAndClass(bis);
+      assertEquals(newObj, beanA);
+      newObj = fury.deserializeJavaObjectAndClass(bis);
+      assertEquals(newObj, beanA);
+
+      fury = Fury.builder().requireClassRegistration(false).build();
+      // test reader buffer grow
+      bis = new ByteArrayInputStream(bas.toByteArray());
+      newObj = fury.deserializeJavaObjectAndClass(bis);
       assertEquals(newObj, beanA);
       newObj = fury.deserializeJavaObjectAndClass(bis);
       assertEquals(newObj, beanA);


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
 Fix  IndexOutOfBoundsException when new fury deserialize from InputStream
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #670 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
