### PR TITLE
[Doc] support front matter

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -11,8 +11,15 @@ jobs:
     steps:    
       - uses: actions/checkout@v2    
 
+      # replace
+      - name: Replace Front Matter
+        run: |
+          sed -i 's/<!-- fury_frontmatter --/---/g' `grep fury_frontmatter -rl`
+          sed -i 's/-- fury_frontmatter -->/---/g' `grep fury_frontmatter -rl`
+
       - name: sync
         uses: BetaHuhn/repo-file-sync-action@v1
         with:
           GH_PAT: ${{ secrets.GH_PAT }}
-          SKIP_PR: true
+          SKIP_PR: true 
+

--- a/docs/guide/java_object_graph_guide.md
+++ b/docs/guide/java_object_graph_guide.md
@@ -1,3 +1,8 @@
+<!-- fury_frontmatter --
+title: Java Object Graph Guide
+order: 0
+-- fury_frontmatter -->
+
 ## Java object graph serialization
 When only java object serialization needed, this mode will have better performance compared to cross-language object graph serialization.
 

--- a/docs/guide/row_format_guide.md
+++ b/docs/guide/row_format_guide.md
@@ -1,3 +1,8 @@
+<!-- fury_frontmatter --
+title: Row Format Guide
+order: 1
+-- fury_frontmatter -->
+
 ## Row format protocol
 ### Java
 ```java

--- a/docs/guide/xlang_object_graph_guide.md
+++ b/docs/guide/xlang_object_graph_guide.md
@@ -1,3 +1,8 @@
+<!-- fury_frontmatter --
+title: Xlang Object Graph Guide
+order: 2
+-- fury_frontmatter -->
+
 ## Cross-language object graph serialization
 
 ### Serialize built-in types


### PR DESCRIPTION
## What do these changes do?
Currently we use "---" as front matter to describe the doc order and title. But in GitHub markdown preview, it does not work fine. So we use the comment "<!-- fury_frontmatter -->" as front matter which can be previewed rightly in GitHub. When syncing to Fury site, we replace the comment front matter back to "---".
