### PR TITLE
[Java] Jdk serialization binary check

### DIFF
--- a/java/fury-core/src/main/java/io/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/io/fury/memory/MemoryBuffer.java
@@ -553,16 +553,12 @@ public final class MemoryBuffer {
     return UNSAFE.getShort(heapMemory, pos);
   }
 
-  /**
-   * Get short in big endian order from provided buffer.
-   */
+  /** Get short in big endian order from provided buffer. */
   public static short getShortB(byte[] b, int off) {
     return (short) ((b[off + 1] & 0xFF) + (b[off] << 8));
   }
 
-  /**
-   * Get short in big endian order from specified offset.
-   */
+  /** Get short in big endian order from specified offset. */
   public short getShortB(int index) {
     final long pos = address + index;
     checkPosition(index, pos, 2);

--- a/java/fury-core/src/main/java/io/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/io/fury/memory/MemoryBuffer.java
@@ -553,10 +553,16 @@ public final class MemoryBuffer {
     return UNSAFE.getShort(heapMemory, pos);
   }
 
+  /**
+   * Get short in big endian order from provided buffer.
+   */
   public static short getShortB(byte[] b, int off) {
     return (short) ((b[off + 1] & 0xFF) + (b[off] << 8));
   }
 
+  /**
+   * Get short in big endian order from specified offset.
+   */
   public short getShortB(int index) {
     final long pos = address + index;
     checkPosition(index, pos, 2);

--- a/java/fury-core/src/main/java/io/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/io/fury/memory/MemoryBuffer.java
@@ -32,8 +32,7 @@ import java.nio.ReadOnlyBufferException;
  * array) or by off-heap memory. Note that the buffer can auto grow on write operations and change
  * into a heap buffer when growing.
  *
- * <p>This class is based on org.apache.flink.core.memory.MemorySegment and
- * org.apache.arrow.memory.ArrowBuf, we add this class mainly for:
+ * <p>This is a byte buffer similar class with more features:
  *
  * <ul>
  *   <li>read/write data into a chunk of direct memory.
@@ -55,6 +54,8 @@ import java.nio.ReadOnlyBufferException;
  */
 // FIXME Buffer operations is most common, and jvm inline and branch elimination
 //  is not reliable even in c2 compiler, so we try to inline and avoid checks as we can manually.
+// Note: This class is based on org.apache.flink.core.memory.MemorySegment and
+//  org.apache.arrow.memory.ArrowBuf.
 public final class MemoryBuffer {
   // The unsafe handle for transparent memory copied (heap/off-heap).
   private static final sun.misc.Unsafe UNSAFE = Platform.UNSAFE;
@@ -550,6 +551,20 @@ public final class MemoryBuffer {
     final long pos = address + index;
     checkPosition(index, pos, 2);
     return UNSAFE.getShort(heapMemory, pos);
+  }
+
+  public static short getShortB(byte[] b, int off) {
+    return (short) ((b[off + 1] & 0xFF) + (b[off] << 8));
+  }
+
+  public short getShortB(int index) {
+    final long pos = address + index;
+    checkPosition(index, pos, 2);
+    if (LITTLE_ENDIAN) {
+      return Short.reverseBytes(UNSAFE.getShort(heapMemory, pos));
+    } else {
+      return UNSAFE.getShort(heapMemory, pos);
+    }
   }
 
   public short getShort(int index) {

--- a/java/fury-core/src/test/java/io/fury/memory/MemoryBufferTest.java
+++ b/java/fury-core/src/test/java/io/fury/memory/MemoryBufferTest.java
@@ -528,4 +528,13 @@ public class MemoryBufferTest {
     buffer.readByte();
     assertEquals(buffer.readPositiveAlignedVarInt(), Integer.MAX_VALUE);
   }
+
+  @Test
+  public void testGetShortB() {
+    byte[] data = new byte[4];
+    data[0] = (byte) 0xac;
+    data[1] = (byte) 0xed;
+    assertEquals(MemoryBuffer.getShortB(data, 0), (short) 0xaced);
+    assertEquals(MemoryBuffer.fromByteArray(data).getShortB(0), (short) 0xaced);
+  }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Add utils to check Jdk serialization binary by check whether frist 2 bytes are `java.io.ObjectStreamConstants#STREAM_MAGIC`.

Users can use following pattern to upgrade serialization to fury in an async rolling-up way:
```java
if (JavaSerializer.serializedByJDK(bytes)) {
  ObjectInputStream objectInputStream = xxx;
  return objectInputStream.readObject();
} else {
  return fury.deserialize(bytes);
}
```
<!-- Please give a short brief about these changes. -->

This method is used only for scenario which client and server can't upgrade at the same time.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #713 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
