### PR TITLE
[JavaScript] Make the protocols of rust and js consistent

### DIFF
--- a/ci/format.sh
+++ b/ci/format.sh
@@ -200,8 +200,8 @@ format_all() {
 
     echo "$(date)" "format javascript...."
     if command -v node >/dev/null; then
-      pushd "$ROOT/javascript"
-      git ls-files -- '*.ts' "${GIT_LS_EXCLUDES[@]}" | xargs -P 5 node ./node_modules/.bin/eslint
+      pushd "$ROOT"
+      git ls-files -- '*.ts' "${GIT_LS_EXCLUDES[@]}" | xargs -P 5 node ./javascript/node_modules/.bin/eslint
       popd
     fi
 
@@ -269,10 +269,10 @@ format_changed() {
     fi
 
     if which node >/dev/null; then
-        pushd "$ROOT/javascript"
+        pushd "$ROOT"
         if ! git diff --diff-filter=ACRM --quiet --exit-code "$MERGEBASE" -- '*.ts' &>/dev/null; then
             git diff --name-only --diff-filter=ACRM "$MERGEBASE" -- '*.ts' | xargs -P 5 \
-                  node ./node_modules/.bin/eslint
+                  node ./javascript/node_modules/.bin/eslint
         fi
         popd
     fi

--- a/javascript/.eslintrc.cjs
+++ b/javascript/.eslintrc.cjs
@@ -5,7 +5,8 @@ module.exports = {
   root: true,
   rules: {
     "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-var-requires": "off",
   },
   ignorePatterns: ["test/*", "dist/*", "*.js"]
 };

--- a/javascript/packages/fury/lib/internalSerializer/array.ts
+++ b/javascript/packages/fury/lib/internalSerializer/array.ts
@@ -17,7 +17,7 @@ const buildTypedArray = <T>(fury: Fury, read: () => void,  write: (p: T) => void
         },
         write: (v: T[]) => {
             serializer.write(v);
-            for (let item of v) {
+            for (const item of v) {
                 write(item);
             }
         },
@@ -108,13 +108,13 @@ export const doubleArraySerializer = (fury: Fury) => {
 
 
 export const arraySerializer = (fury: Fury) => {
-    const { binaryView, binaryWriter, read, referenceResolver, writeNullOrRef, write } = fury;
+    const { binaryView, binaryWriter, referenceResolver, writeNullOrRef } = fury;
     const { pushReadObject, pushWriteObject } = referenceResolver;
-    const { writeInt8, writeInt16, writeInt32 } = binaryWriter;
-    const { readInt32 } = binaryView;
+    const { writeInt8, writeInt16, writeVarInt32 } = binaryWriter;
+    const { readVarInt32 } = binaryView;
     return {
         read: () => {
-            const len = readInt32();
+            const len = readVarInt32();
             const result = new Array(len);
             pushReadObject(result);
             return result;
@@ -126,7 +126,7 @@ export const arraySerializer = (fury: Fury) => {
             writeInt8(RefFlags.RefValueFlag);
             writeInt16(InternalSerializerType.ARRAY);
             pushWriteObject(v);
-            writeInt32(v.length);
+            writeVarInt32(v.length);
         },
         config: () => {
             return {

--- a/javascript/packages/fury/lib/internalSerializer/map.ts
+++ b/javascript/packages/fury/lib/internalSerializer/map.ts
@@ -4,13 +4,13 @@ import { InternalSerializerType, RefFlags, Fury } from "../type";
 
 export default (fury: Fury) => {
     const { binaryView, binaryWriter, writeNullOrRef, read, referenceResolver, write } = fury;
-    const { readUInt32 } = binaryView;
-    const { writeInt8, writeInt16, writeUInt32 } = binaryWriter;
+    const { readVarInt32 } = binaryView;
+    const { writeInt8, writeInt16, writeVarInt32 } = binaryWriter;
     const { pushReadObject, pushWriteObject } = referenceResolver;
 
     return {
         read: () => {
-            const len = readUInt32();
+            const len = readVarInt32();
             const result = new Map();
             pushReadObject(result);
             for (let index = 0; index < len; index++) {
@@ -28,7 +28,7 @@ export default (fury: Fury) => {
             writeInt16(InternalSerializerType.MAP);
             pushWriteObject(v);
             const len = v.size;
-            writeUInt32(len);
+            writeVarInt32(len);
             for (const [key, value] of v.entries()) {
                 write(key);
                 write(value);

--- a/javascript/packages/fury/lib/internalSerializer/set.ts
+++ b/javascript/packages/fury/lib/internalSerializer/set.ts
@@ -4,13 +4,13 @@ import { InternalSerializerType, RefFlags } from "../type";
 
 export default (fury: Fury) => {
     const { binaryView, binaryWriter, writeNullOrRef, referenceResolver, write, read } = fury;
-    const { writeInt8, writeInt16, writeUInt32 } = binaryWriter;
-    const { readUInt32 } = binaryView;
+    const { writeInt8, writeInt16, writeVarInt32 } = binaryWriter;
+    const { readVarInt32 } = binaryView;
 
     const { pushReadObject, pushWriteObject } = referenceResolver;
     return {
         read: () => {
-            const len = readUInt32();
+            const len = readVarInt32();
             const result = new Set();
             pushReadObject(result);
             for (let index = 0; index < len; index++) {
@@ -26,7 +26,7 @@ export default (fury: Fury) => {
             writeInt16(InternalSerializerType.FURY_SET);
             pushWriteObject(v);
             const len = v.size;
-            writeUInt32(len);
+            writeVarInt32(len);
             for (const value of v.values()) {
                 write(value);
             }

--- a/javascript/packages/fury/lib/internalSerializer/string.ts
+++ b/javascript/packages/fury/lib/internalSerializer/string.ts
@@ -1,18 +1,19 @@
 import { Fury } from "../type";
-import { InternalSerializerType, RefFlags, LATIN1 } from "../type";
+import { InternalSerializerType, RefFlags } from "../type";
 
 
 
 export default (fury: Fury) => {
-    const { binaryView, binaryWriter, writeNull, referenceResolver } = fury;
+    const { binaryView, binaryWriter, writeNull } = fury;
     const { writeInt8, writeInt16, writeStringOfVarInt32 } = binaryWriter
-    const { readVarInt32, readStringUtf8, readUInt8, readStringLatin1 } = binaryView;
+    const { readVarInt32, readStringUtf8 } = binaryView;
 
     return {
         read: () => {
-            const type = readUInt8();
+            // todo support latin1
+            //const type = readUInt8();
             const len = readVarInt32();
-            const result = type === LATIN1 ? readStringLatin1(len) : readStringUtf8(len);
+            const result = readStringUtf8(len);
             return result;
         },
         write: (v: string) => {

--- a/javascript/packages/fury/lib/io.ts
+++ b/javascript/packages/fury/lib/io.ts
@@ -1,4 +1,4 @@
-import { Hps, LATIN1, UTF8 } from "./type";
+import { Hps } from "./type";
 
 export const BinaryWriter = (config?: { hps: Hps | null }) => {
     let cursor = 0;
@@ -126,7 +126,8 @@ export const BinaryWriter = (config?: { hps: Hps | null }) => {
             // type and len
             reserves(len);
             // write type
-            dataView.setUint8(move(1), isLatin1 ? LATIN1 : UTF8);
+            // todo support latin1
+            // dataView.setUint8(move(1), isLatin1 ? LATIN1 : UTF8);
             writeVarInt32(len);
             if (isLatin1) {
                 stringCopy(v, i8array, move(len))
@@ -146,7 +147,8 @@ export const BinaryWriter = (config?: { hps: Hps | null }) => {
         // type and len
         reserves(len);
         // write type
-        dataView.setUint8(move(1), isLatin1 ? LATIN1 : UTF8);
+        // todo support latin1
+        // dataView.setUint8(move(1), isLatin1 ? LATIN1 : UTF8);
         writeVarInt32(len);
         if (isLatin1) {
             if (len < 40) {

--- a/javascript/packages/fury/lib/type.ts
+++ b/javascript/packages/fury/lib/type.ts
@@ -80,6 +80,6 @@ export enum RefFlags {
 	RefValueFlag = 0,
 }
 
-export const MaxInt32  = 1<<31 - 1
+export const MaxInt32  = 2147483647;
 export const LATIN1 = 0;
 export const UTF8 = 1;

--- a/javascript/packages/fury/lib/util.ts
+++ b/javascript/packages/fury/lib/util.ts
@@ -13,7 +13,7 @@ const isDotPropAccessor = (prop: string) => {
 
 
 export const replaceBackslashAndQuote = (v: string) => {
-    return v.replace(/\\/g, '\\\\').replace(/"/g, '\\\"')
+    return v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 }
 
 export const safePropAccessor = (prop: string) => {

--- a/javascript/packages/fury/package.json
+++ b/javascript/packages/fury/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@furyjs/fury",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "A blazing fast multi-language serialization framework powered by jit and zero-copy",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && jest",
     "prepublishOnly": "npm run build"
   },
   "files": [

--- a/javascript/test/protocol.test.ts
+++ b/javascript/test/protocol.test.ts
@@ -1,0 +1,48 @@
+import Fury, { TypeDescription, InternalSerializerType, Type } from '@furyjs/fury';
+import { describe, expect, test } from '@jest/globals';
+
+
+describe('protocol', () => {
+    test('should py bin work', () => {
+        const hps = process.env.enableHps ? require('@furyjs/hps') : null;
+        const fury = new Fury({ hps });
+        const { deserialize } = fury.registerSerializer({
+            type: InternalSerializerType.FURY_TYPE_TAG,
+            options: {
+                tag: "example.ComplexObject",
+                props: {
+                    f1: Type.string(),
+                    f2: Type.map(),
+                    f3: Type.int8(),
+                    f4: Type.int16(),
+                    f5: Type.int32(),
+                    f6: Type.int64(),
+                    f7: Type.float(),
+                    f8: Type.double(),
+                    f9: Type.array(Type.int16()),
+                    f10: Type.map(),
+                }
+            }
+        });
+
+        const obj = deserialize(Buffer.from([
+            134, 2, 179, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 81, 159, 160, 124, 69, 240, 2, 120, 21, 0,
+            101, 120, 97, 109, 112, 108, 101, 46, 67, 111, 109, 112, 108, 101, 120, 79, 98, 106, 101,
+            99, 116, 71, 168, 32, 21, 0, 13, 0, 3, 115, 116, 114, 0, 30, 0, 2, 255, 7, 0, 1, 0, 0, 0,
+            255, 12, 0, 85, 85, 85, 85, 85, 85, 213, 63, 255, 7, 0, 100, 0, 0, 0, 255, 12, 0, 146, 36,
+            73, 146, 36, 73, 210, 63, 0, 30, 0, 2, 0, 13, 0, 2, 107, 49, 255, 3, 0, 255, 0, 13, 0, 2,
+            107, 50, 255, 3, 0, 2, 255, 3, 0, 127, 255, 5, 0, 255, 127, 255, 7, 0, 255, 255, 255, 127,
+            255, 9, 0, 255, 255, 255, 255, 255, 255, 255, 127, 255, 11, 0, 0, 0, 0, 63, 255, 12, 0, 85,
+            85, 85, 85, 85, 85, 229, 63, 0, 25, 0, 2, 255, 5, 0, 1, 0, 255, 5, 0, 2, 0, 134, 2, 98, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 81, 159, 160, 124, 69, 240, 2, 120, 21, 0, 101, 120, 97, 109,
+            112, 108, 101, 46, 67, 111, 109, 112, 108, 101, 120, 79, 98, 106, 101, 99, 116, 71, 168,
+            32, 21, 253, 253, 253, 255, 3, 0, 0, 255, 5, 0, 0, 0, 255, 7, 0, 0, 0, 0, 0, 255, 9, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 255, 11, 0, 171, 170, 170, 62, 255, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            253,
+        ]));
+
+        console.log(obj);
+    });
+});
+
+


### PR DESCRIPTION
## What do these changes do?
Make the protocols of rust and js consistent.
- update the hashing algorithm, now it calculates correctly.
- add xlang test. rust should be able to decode binary from python.
- vec updated to use var_int32

## Related issue number
#738 