### PR TITLE
Don't let CI run when the changed files are not the code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ on:
     tags:
       - v*
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.vscode/**'
+      - '.gitignore'
+      - '.github/**'
     types: ['opened', 'reopened', 'synchronize']
 
 jobs:


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
I created this PR #786 to change README.md, it is not the code but github action CI still running. To avoid unnecessary CI runs, it's best to prevent them from triggering when only non-code files have been modified.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
