### PR TITLE
[JavaScript] support polymorphism

### DIFF
--- a/javascript/packages/fury/index.ts
+++ b/javascript/packages/fury/index.ts
@@ -14,9 +14,15 @@
  * limitations under the License.
  */
 
-import { Cast, genSerializer, ObjectTypeDescription, TypeDescription, ArrayTypeDescription } from './lib/codeGen';
-import { Serializer, Fury, InternalSerializerType, Config } from './lib/type';
-import FuryInternal from './lib/fury';
+import {
+    Cast,
+    genSerializer,
+    ObjectTypeDescription,
+    TypeDescription,
+    ArrayTypeDescription,
+} from "./lib/codeGen";
+import { Serializer, Fury, InternalSerializerType, Config } from "./lib/type";
+import FuryInternal from "./lib/fury";
 
 export {
     Serializer,
@@ -24,236 +30,235 @@ export {
     TypeDescription,
     ArrayTypeDescription,
     ObjectTypeDescription,
-}
-
+};
 
 export const Type = {
+    any() {
+        return {
+            type: InternalSerializerType.ANY as const,
+        };
+    },
     string() {
         return {
-            type: InternalSerializerType.STRING as const
-        }
+            type: InternalSerializerType.STRING as const,
+        };
     },
     array<T extends TypeDescription>(def: T) {
         return {
             type: InternalSerializerType.ARRAY as const,
             options: {
-                inner: def
-            }
-        }
+                inner: def,
+            },
+        };
     },
-    map<T1 extends TypeDescription, T2 extends TypeDescription>(key: T1, value: T2) {
+    map<T1 extends TypeDescription, T2 extends TypeDescription>(
+        key: T1,
+        value: T2
+    ) {
         return {
             type: InternalSerializerType.MAP as const,
             options: {
                 key,
-                value
-            }
-        }
+                value,
+            },
+        };
     },
     set<T extends TypeDescription>(key: T) {
         return {
             type: InternalSerializerType.FURY_SET as const,
             options: {
-                key
-            }
-        }
+                key,
+            },
+        };
     },
     bool() {
         return {
             type: InternalSerializerType.BOOL as const,
-        }
+        };
     },
     object<T extends { [key: string]: TypeDescription }>(tag: string, props?: T) {
         return {
             type: InternalSerializerType.FURY_TYPE_TAG as const,
             options: {
                 tag,
-                props
-            }
-        }
+                props,
+            },
+        };
     },
     uint8() {
         return {
             type: InternalSerializerType.UINT8 as const,
-        }
+        };
     },
     uint16() {
         return {
             type: InternalSerializerType.UINT16 as const,
-        }
+        };
     },
     uint32() {
         return {
             type: InternalSerializerType.UINT32 as const,
-        }
+        };
     },
     uint64() {
         return {
             type: InternalSerializerType.UINT64 as const,
-        }
+        };
     },
     int8() {
         return {
             type: InternalSerializerType.INT8 as const,
-        }
+        };
     },
     int16() {
         return {
             type: InternalSerializerType.INT16 as const,
-        }
+        };
     },
     int32() {
         return {
             type: InternalSerializerType.INT32 as const,
-        }
+        };
     },
     int64() {
         return {
             type: InternalSerializerType.INT64 as const,
-        }
+        };
     },
     float() {
         return {
             type: InternalSerializerType.FLOAT as const,
-        }
+        };
     },
     double() {
         return {
             type: InternalSerializerType.DOUBLE as const,
-        }
+        };
     },
     binary() {
         return {
             type: InternalSerializerType.BINARY as const,
-        }
+        };
     },
     date() {
         return {
             type: InternalSerializerType.DATE as const,
-        }
+        };
     },
     timestamp() {
         return {
             type: InternalSerializerType.TIMESTAMP as const,
-        }
-    }
-}
+        };
+    },
+};
 
 //#region template function
 type Props<T> = T extends {
     options: {
-        props?: infer T2 extends { [key: string]: any },
-        tag: string
+        props?: infer T2 extends { [key: string]: any };
+        tag: string;
+    };
+}
+    ? {
+        [P in keyof T2]: ToRecordType<T2[P]>;
     }
-} ? {
-        [P in keyof T2]: ToRecordType<T2[P]>
-    } : unknown
+    : unknown;
 
 type InnerProps<T> = T extends {
     options: {
-        inner: infer T2 extends TypeDescription
-    }
-} ? ToRecordType<T2>[] : unknown
+        inner: infer T2 extends TypeDescription;
+    };
+}
+    ? ToRecordType<T2>[]
+    : unknown;
 
 type MapProps<T> = T extends {
     options: {
-        key: infer T2 extends TypeDescription
-        value: infer T3 extends TypeDescription
-    }
-} ? Map<ToRecordType<T2>, ToRecordType<T3>> : unknown
+        key: infer T2 extends TypeDescription;
+        value: infer T3 extends TypeDescription;
+    };
+}
+    ? Map<ToRecordType<T2>, ToRecordType<T3>>
+    : unknown;
 
 type SetProps<T> = T extends {
     options: {
-        key: infer T2 extends TypeDescription
-    }
-} ? Set<ToRecordType<T2>> : unknown
+        key: infer T2 extends TypeDescription;
+    };
+}
+    ? Set<ToRecordType<T2>>
+    : unknown;
 
 export type ToRecordType<T> = T extends {
-    type: InternalSerializerType.FURY_TYPE_TAG
-} ? (
-        Props<T>
-    ) : (
-        T extends {
-            type: InternalSerializerType.STRING
-        } ? (
-            string
-        ) : (
-            T extends {
-                type: InternalSerializerType.UINT8
-                | InternalSerializerType.UINT16
-                | InternalSerializerType.UINT32
-                | InternalSerializerType.UINT64
-                | InternalSerializerType.INT8
-                | InternalSerializerType.INT16
-                | InternalSerializerType.INT32
-                | InternalSerializerType.INT64
-                | InternalSerializerType.FLOAT
-                | InternalSerializerType.DOUBLE
-
-            } ? (
-                number
-            ) : (
-                T extends {
-                    type: InternalSerializerType.MAP
-                } ? (
-                    MapProps<T>
-                ) :
-                T extends {
-                    type: InternalSerializerType.FURY_SET
-                } ? (
-                    SetProps<T>
-                ) : (
-                    T extends {
-                        type: InternalSerializerType.ARRAY
-                    } ? (
-                        InnerProps<T>
-                    ) : (
-                        T extends {
-                            type: InternalSerializerType.BOOL
-                        } ? (
-                            boolean
-                        ) : (
-                            T extends {
-                                type: InternalSerializerType.DATE
-                            } ? (
-                                Date
-                            ) : (
-                                T extends {
-                                    type: InternalSerializerType.TIMESTAMP
-                                } ? (
-                                    number
-                                ) : (
-                                    T extends {
-                                        type: InternalSerializerType.BINARY
-                                    } ? (
-                                        Buffer
-                                    ) : unknown
-                                )
-                            )
-                        )
-                    )
-                )
-            )
-        )
-    )
+    type: InternalSerializerType.FURY_TYPE_TAG;
+}
+    ? Props<T>
+    : T extends {
+        type: InternalSerializerType.STRING;
+    }
+    ? string
+    : T extends {
+        type:
+        | InternalSerializerType.UINT8
+        | InternalSerializerType.UINT16
+        | InternalSerializerType.UINT32
+        | InternalSerializerType.UINT64
+        | InternalSerializerType.INT8
+        | InternalSerializerType.INT16
+        | InternalSerializerType.INT32
+        | InternalSerializerType.INT64
+        | InternalSerializerType.FLOAT
+        | InternalSerializerType.DOUBLE;
+    }
+    ? number
+    : T extends {
+        type: InternalSerializerType.MAP;
+    }
+    ? MapProps<T>
+    : T extends {
+        type: InternalSerializerType.FURY_SET;
+    }
+    ? SetProps<T>
+    : T extends {
+        type: InternalSerializerType.ARRAY;
+    }
+    ? InnerProps<T>
+    : T extends {
+        type: InternalSerializerType.BOOL;
+    }
+    ? boolean
+    : T extends {
+        type: InternalSerializerType.DATE;
+    }
+    ? Date
+    : T extends {
+        type: InternalSerializerType.TIMESTAMP;
+    }
+    ? number
+    : T extends {
+        type: InternalSerializerType.BINARY;
+    }
+    ? Buffer
+    : T extends {
+        type: InternalSerializerType.ANY;
+    }
+    ? any
+    : unknown;
 
 //#endregion
 
-
 export default class {
-    constructor(private config?: Config) {
-
-    }
+    constructor(private config?: Config) { }
     private fury: Fury = FuryInternal(this.config || {});
 
     registerSerializer<T extends TypeDescription>(description: T) {
-        if (description.type !== InternalSerializerType.FURY_TYPE_TAG || !Cast<ObjectTypeDescription>(description)?.options.tag) {
-            throw new Error('root type should be object')
+        if (
+            description.type !== InternalSerializerType.FURY_TYPE_TAG ||
+            !Cast<ObjectTypeDescription>(description)?.options.tag
+        ) {
+            throw new Error("root type should be object");
         }
-        const serializer = genSerializer(
-            this.fury,
-            description,
-        );
+        const serializer = genSerializer(this.fury, description);
         return {
             serializer,
             serialize: (data: ToRecordType<T>) => {
@@ -261,8 +266,8 @@ export default class {
             },
             deserialize: (bytes: Buffer) => {
                 return this.fury.deserialize(bytes) as ToRecordType<T>;
-            }
-        }
+            },
+        };
     }
 
     serialize(v: any, serialize?: Serializer) {

--- a/javascript/packages/fury/lib/classResolver.ts
+++ b/javascript/packages/fury/lib/classResolver.ts
@@ -28,27 +28,19 @@ import anySerializer from './internalSerializer/any';
 const USESTRINGVALUE = 0;
 const USESTRINGID = 1
 
-const unreachable = () => {
-    throw new Error('unreachable serializer')
-}
-
-export const unreachableSerializer = () => {
-    return {
-        read: unreachable,
-        write: unreachable
-    }
-}
 export default class SerializerResolver {
-    private internalSerializer: Serializer[] = new Array(300).fill(unreachableSerializer());
+    private internalSerializer: Serializer[] = new Array(300);
     private customSerializer: { [key: string]: Serializer } = {
     };
     private readStringPool: string[] = [];
     private writeStringIndex: string[] = [];
 
     private initInternalSerializer(fury: Fury) {
+        const _anySerializer = anySerializer(fury);
+        this.internalSerializer[InternalSerializerType.ANY] = _anySerializer;
         this.internalSerializer[InternalSerializerType.STRING] = stringSerializer(fury);
-        this.internalSerializer[InternalSerializerType.ARRAY] = arraySerializer(fury, anySerializer(fury));
-        this.internalSerializer[InternalSerializerType.MAP] = mapSerializer(fury, anySerializer(fury), anySerializer(fury));
+        this.internalSerializer[InternalSerializerType.ARRAY] = arraySerializer(fury, _anySerializer);
+        this.internalSerializer[InternalSerializerType.MAP] = mapSerializer(fury, _anySerializer, _anySerializer);
         this.internalSerializer[InternalSerializerType.BOOL] = boolSerializer(fury);
         this.internalSerializer[InternalSerializerType.UINT8] = uInt8Serializer(fury);
         this.internalSerializer[InternalSerializerType.INT8] = int8Serializer(fury);
@@ -90,7 +82,7 @@ export default class SerializerResolver {
         if (this.customSerializer[tag]) {
             Object.assign(this.customSerializer[tag], serializer);
         } else {
-            this.customSerializer[tag] = serializer;
+            this.customSerializer[tag] = {...serializer};
         }
         return this.customSerializer[tag]
     }

--- a/javascript/packages/fury/lib/fury.ts
+++ b/javascript/packages/fury/lib/fury.ts
@@ -18,8 +18,7 @@ import ClassResolver from './classResolver';
 import { BinaryWriter } from './writer';
 import { BinaryReader } from './reader';
 import { ReferenceResolver } from './referenceResolver';
-import { ConfigFlags, Serializer, Config } from './type';
-import anySerializer from './internalSerializer/any';
+import { ConfigFlags, Serializer, Config, InternalSerializerType } from './type';
 
 export default (config: Config) => {
     const binaryReader = BinaryReader(config);
@@ -63,7 +62,7 @@ export default (config: Config) => {
         }
         binaryReader.int32(); // native object offset. should skip.  javascript support cross mode only
         binaryReader.int32(); // native object size. should skip.
-        return anySerializer(fury).read();
+        return classResolver.getSerializerById(InternalSerializerType.ANY).read();
     }
 
     function serialize<T = any>(data: T, serializer?: Serializer) {
@@ -83,7 +82,7 @@ export default (config: Config) => {
         if (serializer) {
             serializer.write(data);
         } else {
-            anySerializer(fury).write(data);
+            classResolver.getSerializerById(InternalSerializerType.ANY).write(data);
         }
         return binaryWriter.dump();
     }

--- a/javascript/packages/fury/lib/internalSerializer/any.ts
+++ b/javascript/packages/fury/lib/internalSerializer/any.ts
@@ -22,13 +22,6 @@ import { InternalSerializerType, RefFlags } from "../type";
 
 export default (fury: Fury) => {
     const { binaryReader, binaryWriter, referenceResolver, classResolver } = fury;
-    const { write: writeInt64, config: int64Config } = classResolver.getSerializerById(InternalSerializerType.INT64);
-    const { write: writeBool, config: boolConfig } = classResolver.getSerializerById(InternalSerializerType.BOOL);
-    const { write: stringWrite, config: stringConfig } = classResolver.getSerializerById(InternalSerializerType.STRING);
-    const { write: arrayWrite, config: arrayConfig } = classResolver.getSerializerById(InternalSerializerType.ARRAY);
-    const { write: mapWrite, config: mapConfig } = classResolver.getSerializerById(InternalSerializerType.MAP);
-    const { write: setWrite, config: setConfig } = classResolver.getSerializerById(InternalSerializerType.FURY_SET);
-    const { write: timestampWrite, config: timestampConfig } = classResolver.getSerializerById(InternalSerializerType.TIMESTAMP);
 
 
     function readSerializer(cursor: number) {
@@ -63,6 +56,14 @@ export default (fury: Fury) => {
             }
         },
         write: (v: any) => {
+            const { write: writeInt64, config: int64Config } = classResolver.getSerializerById(InternalSerializerType.INT64);
+            const { write: writeBool, config: boolConfig } = classResolver.getSerializerById(InternalSerializerType.BOOL);
+            const { write: stringWrite, config: stringConfig } = classResolver.getSerializerById(InternalSerializerType.STRING);
+            const { write: arrayWrite, config: arrayConfig } = classResolver.getSerializerById(InternalSerializerType.ARRAY);
+            const { write: mapWrite, config: mapConfig } = classResolver.getSerializerById(InternalSerializerType.MAP);
+            const { write: setWrite, config: setConfig } = classResolver.getSerializerById(InternalSerializerType.FURY_SET);
+            const { write: timestampWrite, config: timestampConfig } = classResolver.getSerializerById(InternalSerializerType.TIMESTAMP);
+        
             // NullFlag
             if (v === null || v === undefined) {
                 binaryWriter.reserve(1);

--- a/javascript/packages/fury/lib/type.ts
+++ b/javascript/packages/fury/lib/type.ts
@@ -50,6 +50,7 @@ export enum InternalSerializerType{
 	FURY_PRIMITIVE_FLOAT_ARRAY = 262,
 	FURY_PRIMITIVE_DOUBLE_ARRAY = 263,
 	FURY_STRING_ARRAY = 264,
+	ANY = -1,
 }
 
 

--- a/javascript/test/protocol.test.ts
+++ b/javascript/test/protocol.test.ts
@@ -19,6 +19,27 @@ import { describe, expect, test } from '@jest/globals';
 
 
 describe('protocol', () => {
+    test('should polymorphic work', () => {
+        const hps = process.env.enableHps ? require('@furyjs/hps') : null;
+        const fury = new Fury({ refTracking: true, hps });
+        const { serialize, deserialize } = fury.registerSerializer(Type.object("example.foo", {
+            foo: Type.any(),
+            bar: Type.any(),
+            map: Type.map(Type.any(), Type.any()),
+            set: Type.set(Type.any()),
+            list: Type.array(Type.any()),
+        }));
+        const obj = {
+            foo: "123",
+            bar: 123,
+            map: new Map([["hello", 1], ["world", 2]]),
+            set: new Set([1, 2, "123"]),
+            list: ["123", 123, true]
+        };
+        const bf = serialize(obj);
+        const result = deserialize(bf);
+        expect(result).toEqual(obj);
+    });
     test('should py bin work', () => {
         const hps = process.env.enableHps ? require('@furyjs/hps') : null;
         const fury = new Fury({ refTracking: true, hps });
@@ -28,7 +49,7 @@ describe('protocol', () => {
                 tag: "example.ComplexObject",
                 props: {
                     f1: Type.string(),
-                    f2: Type.map(Type.string(), Type.string()),
+                    f2: Type.map(Type.string(), Type.any()),
                     f3: Type.int8(),
                     f4: Type.int16(),
                     f5: Type.int32(),
@@ -57,7 +78,18 @@ describe('protocol', () => {
             253,
         ]));
 
-        console.log(obj);
+        expect(obj).toEqual({
+            f1: "str",
+            f10: new Map([[1, 1 / 3], [100, 2 / 7]]),
+            f2: new Map([['k1', -1], ['k2', 2]]),
+            f3: 2**7 - 1,
+            f4: 2**15 - 1,
+            f5: 2**31 - 1,
+            f6: 2**63 - 1,
+            f7: 1 / 2,
+            f8: 2 / 3,
+            f9: [1, 2]
+        })
     });
 });
 


### PR DESCRIPTION

## What do these changes do?

- Add a tool function called Type.Any which would use the anySerializer during compile time. 
- Fixed a bug where the dependencies serializer was null when build anySerializer, so we can't init the dependencies serializer when build it. We replaced it by getting the serializer by ID or tag every time we read or write. However, this modification could hurt the performance of Type.Any.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #813 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
