### PR TITLE
[Java] fix isSecure check for xlang in java

### DIFF
--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -389,6 +389,7 @@ public class ClassResolver {
           "Java serialization should register class by "
               + "Fury#register(Class) or Fury.register(Class<?>, Short)");
     }
+    register(cls);
     Preconditions.checkArgument(!typeTagToClassXLangMap.containsKey(typeTag));
     addSerializer(cls, new StructSerializer<>(fury, cls, typeTag));
   }
@@ -1023,14 +1024,11 @@ public class ClassResolver {
     return Serializers.newSerializer(fury, cls, serializerClass);
   }
 
-  private boolean isSecure(IdentityMap<Class<?>, Short> registeredClasses, Class<?> cls) {
+  private static boolean isSecure(IdentityMap<Class<?>, Short> registeredClasses, Class<?> cls) {
     if (BlackList.getDefaultBlackList().contains(cls.getName())) {
       return false;
     }
     if (registeredClasses.containsKey(cls)) {
-      return true;
-    }
-    if (fury.getLanguage() == Language.XLANG && getSerializer(cls, false) != null) {
       return true;
     }
     if (cls.isArray()) {

--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -1023,11 +1023,14 @@ public class ClassResolver {
     return Serializers.newSerializer(fury, cls, serializerClass);
   }
 
-  private static boolean isSecure(IdentityMap<Class<?>, Short> registeredClasses, Class<?> cls) {
+  private boolean isSecure(IdentityMap<Class<?>, Short> registeredClasses, Class<?> cls) {
     if (BlackList.getDefaultBlackList().contains(cls.getName())) {
       return false;
     }
     if (registeredClasses.containsKey(cls)) {
+      return true;
+    }
+    if (fury.getLanguage() == Language.XLANG && getSerializer(cls, false) != null) {
       return true;
     }
     if (cls.isArray()) {

--- a/java/fury-core/src/test/java/io/fury/CrossLanguageTest.java
+++ b/java/fury-core/src/test/java/io/fury/CrossLanguageTest.java
@@ -709,4 +709,27 @@ public class CrossLanguageTest {
       Assert.assertEquals(data.get(i), newObj.get(i));
     }
   }
+
+  @Data
+  static class ArrayStruct {
+    ArrayField[] f1;
+  }
+
+  @Data
+  static class ArrayField {
+    public String a;
+  }
+
+  @Test
+  public void testStructArrayField() {
+    Fury fury = Fury.builder().withLanguage(Language.XLANG).requireClassRegistration(true).build();
+    fury.register(ArrayStruct.class, "example.bar");
+    fury.register(ArrayField.class, "example.foo");
+
+    ArrayField a = new ArrayField();
+    a.a = "123";
+    ArrayStruct struct = new ArrayStruct();
+    struct.f1 = new ArrayField[] {a};
+    Assert.assertEquals(serDe(fury, struct), struct);
+  }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
fix isSecure check for xlang in java: register class by type tag only register serializer, but didn't register classes, which make class secure check failed.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
 #703 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
