### PR TITLE
[Java] register empty object by default

### DIFF
--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -197,6 +197,7 @@ public class ClassResolver {
   public static final short HASHMAP_CLASS_ID = (short) (PRIMITIVE_DOUBLE_ARRAY_CLASS_ID + 4);
   public static final short HASHSET_CLASS_ID = (short) (PRIMITIVE_DOUBLE_ARRAY_CLASS_ID + 5);
   public static final short CLASS_CLASS_ID = (short) (PRIMITIVE_DOUBLE_ARRAY_CLASS_ID + 6);
+  public static final short EMPTY_OBJECT_ID = (short) (PRIMITIVE_DOUBLE_ARRAY_CLASS_ID + 7);
   private static final int initialCapacity = 128;
   // use a lower load factor to minimize hash collision
   private static final float loadFactor = 0.25f;
@@ -291,6 +292,7 @@ public class ClassResolver {
     registerWithCheck(HashMap.class, HASHMAP_CLASS_ID);
     registerWithCheck(HashSet.class, HASHSET_CLASS_ID);
     registerWithCheck(Class.class, CLASS_CLASS_ID);
+    registerWithCheck(Object.class, EMPTY_OBJECT_ID);
     addDefaultSerializers();
     registerDefaultClasses();
     innerEndClassId = extRegistry.registeredClassIdCounter;

--- a/java/fury-core/src/main/java/io/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/Serializers.java
@@ -684,6 +684,28 @@ public class Serializers {
     }
   }
 
+  /**
+   * Serializer for empty object of type {@link Object}. Fury disabled serialization for jdk
+   * internal types which doesn't implement {@link java.io.Serializable} for security, but empty
+   * object is safe and used sometimes, so fury should support its serialization without disable
+   * serializable or class registration checks.
+   */
+  // Use a separate serializer to avoid codegen for emtpy object.
+  public static final class EmptyObjectSerializer extends Serializer<Object> {
+
+    public EmptyObjectSerializer(Fury fury) {
+      super(fury, Object.class);
+    }
+
+    @Override
+    public void write(MemoryBuffer buffer, Object value) {}
+
+    @Override
+    public Object read(MemoryBuffer buffer) {
+      return new Object();
+    }
+  }
+
   public static void registerDefaultSerializers(Fury fury) {
     // primitive types will be boxed.
     fury.registerSerializer(boolean.class, new BooleanSerializer(fury, boolean.class));
@@ -715,5 +737,6 @@ public class Serializers {
     fury.registerSerializer(URI.class, new URISerializer(fury));
     fury.registerSerializer(Pattern.class, new RegexSerializer(fury));
     fury.registerSerializer(UUID.class, new UUIDSerializer(fury));
+    fury.registerSerializer(Object.class, new EmptyObjectSerializer(fury));
   }
 }

--- a/java/fury-core/src/main/java/io/fury/serializer/StructSerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/StructSerializer.java
@@ -225,7 +225,11 @@ public class StructSerializer<T> extends Serializer<T> {
     } else {
       try {
         Serializer<?> serializer = fury.getClassResolver().getSerializer(fieldGeneric.getCls());
-        id = Math.abs(serializer.getXtypeId());
+        short xtypeId = serializer.getXtypeId();
+        if (xtypeId == Fury.NOT_SUPPORT_CROSS_LANGUAGE) {
+          return hash;
+        }
+        id = Math.abs(xtypeId);
         if (id == Type.FURY_TYPE_TAG.getId()) {
           id = TypeUtils.computeStringHash(serializer.getCrossLanguageTypeTag());
         }

--- a/java/fury-core/src/test/java/io/fury/serializer/SerializersTest.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/SerializersTest.java
@@ -17,6 +17,7 @@
 package io.fury.serializer;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
@@ -203,5 +204,11 @@ public class SerializersTest extends FuryTestBase {
     serDeCheckSerializer(fury, TestClassSerialization.class, "ClassSerializer");
     serDeCheckSerializer(fury, TestReplaceClassSerialization.class, "ClassSerializer");
     serDe(fury, new TestReplaceClassSerialization());
+  }
+
+  @Test
+  public void testEmptyObject() {
+    Fury fury = Fury.builder().requireClassRegistration(true).build();
+    assertSame(serDe(fury, new Object()).getClass(), Object.class);
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Fury disabled serialization for jdk internal types which doesn't implement java.io.Serializable for security, but empty object is safe and used sometimes, so fury should support its serialization without disable serializable or class registration checks.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? --> #826

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
