### PR TITLE
[Java] use java.lang.ClassValue to cache Lookup

### DIFF
--- a/java/fury-core/src/main/java/io/fury/util/unsafe/_JDKAccess.java
+++ b/java/fury-core/src/main/java/io/fury/util/unsafe/_JDKAccess.java
@@ -73,7 +73,7 @@ public class _JDKAccess {
     }
   }
 
-  private static final ClassValue<Lookup> lookup_ = new ClassValue<Lookup>() {
+  private static final ClassValue<Lookup> lookupCache = new ClassValue<Lookup>() {
     @Override
     protected Lookup computeValue(Class type) {
       return _Lookup._trustedLookup(type);
@@ -84,7 +84,7 @@ public class _JDKAccess {
 
   public static Lookup _trustedLookup(Class<?> objectClass) {
     // CHECKSTYLE.ON:MethodName
-    return lookup_.get(objectClass);
+    return lookupCache.get(objectClass);
   }
 
   public static <T> T tryMakeFunction(

--- a/java/fury-core/src/main/java/io/fury/util/unsafe/_JDKAccess.java
+++ b/java/fury-core/src/main/java/io/fury/util/unsafe/_JDKAccess.java
@@ -73,11 +73,18 @@ public class _JDKAccess {
     }
   }
 
+  private static final ClassValue<Lookup> lookup_ = new ClassValue<Lookup>() {
+    @Override
+    protected Lookup computeValue(Class type) {
+      return _Lookup._trustedLookup(type);
+    }
+  };
+
   // CHECKSTYLE.OFF:MethodName
 
   public static Lookup _trustedLookup(Class<?> objectClass) {
     // CHECKSTYLE.ON:MethodName
-    return _Lookup._trustedLookup(objectClass);
+    return lookup_.get(objectClass);
   }
 
   public static <T> T tryMakeFunction(

--- a/java/fury-core/src/main/java/io/fury/util/unsafe/_JDKAccess.java
+++ b/java/fury-core/src/main/java/io/fury/util/unsafe/_JDKAccess.java
@@ -73,12 +73,13 @@ public class _JDKAccess {
     }
   }
 
-  private static final ClassValue<Lookup> lookupCache = new ClassValue<Lookup>() {
-    @Override
-    protected Lookup computeValue(Class type) {
-      return _Lookup._trustedLookup(type);
-    }
-  };
+  private static final ClassValue<Lookup> lookupCache =
+      new ClassValue<Lookup>() {
+        @Override
+        protected Lookup computeValue(Class type) {
+          return _Lookup._trustedLookup(type);
+        }
+      };
 
   // CHECKSTYLE.OFF:MethodName
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
`Lookup` creation is not cheap.
ClassValue is thread safe, and weakref,  we can use ClassValue to cache it.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #xxxx

## Check code requirements
https://bugs.openjdk.org/browse/JDK-8136353
- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
