### PR TITLE
[Java] Optimize jdk9+ immutable collection serialization 

### DIFF
--- a/integration_tests/latest_jdk_tests/src/test/java/io/fury/integration_tests/ImmutableCollectionSerializersTest.java
+++ b/integration_tests/latest_jdk_tests/src/test/java/io/fury/integration_tests/ImmutableCollectionSerializersTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.integration_tests;
+
+import static io.fury.integration_tests.TestUtils.serDeCheck;
+
+import io.fury.Fury;
+import io.fury.test.bean.CollectionFields;
+import io.fury.test.bean.MapFields;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ImmutableCollectionSerializersTest {
+
+  @DataProvider
+  public static Object[][] codegen() {
+    return new Object[][] {{false}, {true}};
+  }
+
+  @Test(dataProvider = "codegen")
+  public void testImmutableCollections(boolean codegen) {
+    Fury fury = Fury.builder().withCodegen(codegen).build();
+    serDeCheck(fury, List.of());
+    serDeCheck(fury, List.of("A"));
+    serDeCheck(fury, List.of("A", "B"));
+    serDeCheck(fury, List.of("A", "B", "C"));
+    serDeCheck(fury, List.of("A", "B", "C", "D"));
+    serDeCheck(fury, List.of("A", "B", 1, 2));
+    serDeCheck(fury, Set.of());
+    serDeCheck(fury, Set.of("A"));
+    serDeCheck(fury, Set.of("A", "B"));
+    serDeCheck(fury, Set.of("A", "B", "C"));
+    serDeCheck(fury, Set.of("A", "B", "C", "D"));
+    serDeCheck(fury, Set.of("A", "B", 1, 2));
+    serDeCheck(fury, Map.of());
+    serDeCheck(fury, Map.of("A", "B"));
+    serDeCheck(fury, Map.of("A", "B", 1, 2));
+  }
+
+  @Test(dataProvider = "codegen")
+  public void testImmutableCollectionStruct(boolean codegen) {
+    Fury fury = Fury.builder().withCodegen(codegen).build();
+    fury.register(MapFields.class);
+    MapFields mapFields = new MapFields();
+    mapFields.map = Map.of();
+    mapFields.map2 = Map.of("k", 1);
+    mapFields.mapKeyFinal = Map.of("k", 1);
+    mapFields.mapValueFinal = Map.of("k", 2, "k2", 2, "k3", 3);
+    mapFields.emptyMap = Map.of();
+    mapFields.singletonMap = Map.of(1, 2);
+    serDeCheck(fury, mapFields);
+  }
+
+  @Test
+  public void testImmutableMapStruct() {
+    Fury fury = Fury.builder().build();
+    fury.register(CollectionFields.class);
+    CollectionFields collectionFields = new CollectionFields();
+    collectionFields.collection = List.of();
+    collectionFields.collection2 = List.of(1);
+    collectionFields.collection3 = List.of(1, 2, 3, 4);
+    collectionFields.randomAccessList = List.of("1", "2");
+    collectionFields.randomAccessList2 = List.of("1", "2", "3", "4");
+    collectionFields.set = Set.of();
+    collectionFields.set2 = Set.of("1", "2");
+    collectionFields.set3 = Set.of("1", "2", "3", "4");
+    collectionFields.map = Map.of("1", "2");
+    collectionFields.map2 = Map.of("1", "2", "3", "4");
+    serDeCheck(fury, collectionFields);
+  }
+}

--- a/integration_tests/latest_jdk_tests/src/test/java/io/fury/integration_tests/TestUtils.java
+++ b/integration_tests/latest_jdk_tests/src/test/java/io/fury/integration_tests/TestUtils.java
@@ -1,0 +1,18 @@
+package io.fury.integration_tests;
+
+import io.fury.Fury;
+import org.testng.Assert;
+
+@SuppressWarnings("unchecked")
+public class TestUtils {
+  public static <T> T serDe(Fury fury, T obj) {
+    byte[] bytes = fury.serialize(obj);
+    return (T) (fury.deserialize(bytes));
+  }
+
+  public static Object serDeCheck(Fury fury, Object obj) {
+    Object o = serDe(fury, obj);
+    Assert.assertEquals(o, obj);
+    return o;
+  }
+}

--- a/integration_tests/latest_jdk_tests/src/test/java/io/fury/integration_tests/TestUtils.java
+++ b/integration_tests/latest_jdk_tests/src/test/java/io/fury/integration_tests/TestUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.fury.integration_tests;
 
 import io.fury.Fury;

--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -55,6 +55,7 @@ import io.fury.serializer.CompatibleMode;
 import io.fury.serializer.CompatibleSerializer;
 import io.fury.serializer.ExternalizableSerializer;
 import io.fury.serializer.GuavaSerializers;
+import io.fury.serializer.ImmutableCollectionSerializers;
 import io.fury.serializer.JavaSerializer;
 import io.fury.serializer.JdkProxySerializer;
 import io.fury.serializer.LambdaSerializer;
@@ -321,6 +322,7 @@ public class ClassResolver {
         new ReplaceResolveSerializer(fury, ReplaceResolveSerializer.ReplaceStub.class));
     SynchronizedSerializers.registerSerializers(fury);
     UnmodifiableSerializers.registerSerializers(fury);
+    ImmutableCollectionSerializers.registerSerializers(fury);
     if (metaContextShareEnabled) {
       addDefaultSerializer(
           UnexistedMetaSharedClass.class, new UnexistedClassSerializer(fury, null));

--- a/java/fury-core/src/main/java/io/fury/serializer/Container.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/Container.java
@@ -110,3 +110,33 @@ class SortedMapContainer<K, V> extends MapContainer<K, V> {
     this.comparator = comparator;
   }
 }
+
+/**
+ * A map container to hold map key and value elements in one array.
+ *
+ * @author chaokunyang
+ */
+class JDKImmutableMapContainer<K, V> extends AbstractMap<K, V> {
+  final Object[] array;
+  private int offset;
+
+  JDKImmutableMapContainer(int mapCapacity) {
+    array = new Object[mapCapacity << 1];
+  }
+
+  @Override
+  public Set<Entry<K, V>> entrySet() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public V put(K key, V value) {
+    array[offset++] = key;
+    array[offset++] = value;
+    return null;
+  }
+
+  public int size() {
+    return offset >> 1;
+  }
+}

--- a/java/fury-core/src/main/java/io/fury/serializer/ImmutableCollectionSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/ImmutableCollectionSerializers.java
@@ -1,0 +1,189 @@
+package io.fury.serializer;
+
+import io.fury.Fury;
+import io.fury.memory.MemoryBuffer;
+import io.fury.util.Platform;
+import io.fury.util.unsafe._JDKAccess;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Serializers for jdk9+ java.util.ImmutableCollections.
+ *
+ * @author chaokunyang
+ */
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class ImmutableCollectionSerializers {
+  private static Class<?> List12;
+  private static Class<?> ListN;
+  private static Class<?> SubList;
+  private static Class<?> Set12;
+  private static Class<?> SetN;
+  private static Class<?> Map1;
+  private static Class<?> MapN;
+  private static MethodHandle listFactory;
+  private static MethodHandle setFactory;
+  private static MethodHandle map1Factory;
+  private static MethodHandle mapNFactory;
+
+  static {
+    if (Platform.JAVA_VERSION > 8) {
+      try {
+        List12 = Class.forName("java.util.ImmutableCollections$List12");
+        ListN = Class.forName("java.util.ImmutableCollections$ListN");
+        SubList = Class.forName("java.util.ImmutableCollections$SubList");
+        Set12 = Class.forName("java.util.ImmutableCollections$Set12");
+        SetN = Class.forName("java.util.ImmutableCollections$SetN");
+        Map1 = Class.forName("java.util.ImmutableCollections$Map1");
+        MapN = Class.forName("java.util.ImmutableCollections$MapN");
+        listFactory =
+            _JDKAccess._trustedLookup(List.class)
+                .findStatic(List.class, "of", MethodType.methodType(List.class, Object[].class));
+        setFactory =
+            _JDKAccess._trustedLookup(Set.class)
+                .findStatic(Set.class, "of", MethodType.methodType(Set.class, Object[].class));
+        map1Factory =
+            _JDKAccess._trustedLookup(Map1)
+                .findConstructor(
+                    Map1, MethodType.methodType(void.class, Object.class, Object.class));
+        mapNFactory =
+            _JDKAccess._trustedLookup(MapN)
+                .findConstructor(MapN, MethodType.methodType(void.class, Object[].class));
+      } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException e) {
+        e.printStackTrace();
+        Platform.throwException(e);
+      }
+    } else {
+      // Use stub class as placeholder to ensure jdk8 registered id consistent with JDK9+.
+      class List12Stub {}
+      class ListNStub {}
+      class SubListStub {}
+      class Set12Stub {}
+      class SetNStub {}
+      class Map1Stub {}
+      class MapNStub {}
+      List12 = List12Stub.class;
+      ListN = ListNStub.class;
+      SubList = SubListStub.class;
+      Set12 = Set12Stub.class;
+      SetN = SetNStub.class;
+      Map1 = Map1Stub.class;
+      MapN = MapNStub.class;
+    }
+  }
+
+  public static class ImmutableListSerializer extends CollectionSerializers.CollectionSerializer {
+    public ImmutableListSerializer(Fury fury, Class cls) {
+      super(fury, cls, true, false);
+    }
+
+    @Override
+    public Collection newCollection(MemoryBuffer buffer, int numElements) {
+      if (Platform.JAVA_VERSION > 8) {
+        return new CollectionContainer<>(numElements);
+      } else {
+        return new ArrayList(numElements);
+      }
+    }
+
+    @Override
+    public Collection onCollectionRead(Collection collection) {
+      if (Platform.JAVA_VERSION > 8) {
+        CollectionContainer container = (CollectionContainer) collection;
+        try {
+          collection = (List) listFactory.invoke(container.elements);
+        } catch (Throwable e) {
+          throw new RuntimeException(e);
+        }
+      } else {
+        collection = Collections.unmodifiableList((List) collection);
+      }
+      fury.getRefResolver().reference(collection);
+      return collection;
+    }
+  }
+
+  public static class ImmutableSetSerializer extends CollectionSerializers.CollectionSerializer {
+    public ImmutableSetSerializer(Fury fury, Class cls) {
+      super(fury, cls, true, false);
+    }
+
+    @Override
+    public Collection newCollection(MemoryBuffer buffer, int numElements) {
+      if (Platform.JAVA_VERSION > 8) {
+        return new CollectionContainer<>(numElements);
+      } else {
+        return new HashSet(numElements);
+      }
+    }
+
+    @Override
+    public Collection onCollectionRead(Collection collection) {
+      if (Platform.JAVA_VERSION > 8) {
+        CollectionContainer container = (CollectionContainer) collection;
+        try {
+          collection = (Set) setFactory.invoke(container.elements);
+        } catch (Throwable e) {
+          throw new RuntimeException(e);
+        }
+      } else {
+        collection = Collections.unmodifiableSet((HashSet) collection);
+      }
+      fury.getRefResolver().reference(collection);
+      return collection;
+    }
+  }
+
+  public static class ImmutableMapSerializer extends MapSerializers.MapSerializer {
+    public ImmutableMapSerializer(Fury fury, Class cls) {
+      super(fury, cls, true, false);
+    }
+
+    @Override
+    public Map newMap(MemoryBuffer buffer, int numElements) {
+      if (Platform.JAVA_VERSION > 8) {
+        return new JDKImmutableMapContainer(numElements);
+      } else {
+        return new HashMap(numElements);
+      }
+    }
+
+    @Override
+    public Map onMapRead(Map map) {
+      if (Platform.JAVA_VERSION > 8) {
+        JDKImmutableMapContainer container = (JDKImmutableMapContainer) map;
+        try {
+          if (container.size() == 1) {
+            map = (Map) map1Factory.invoke(container.array[0], container.array[1]);
+          } else {
+            map = (Map) mapNFactory.invoke(container.array);
+          }
+        } catch (Throwable e) {
+          throw new RuntimeException(e);
+        }
+      } else {
+        map = Collections.unmodifiableMap(map);
+      }
+      fury.getRefResolver().reference(map);
+      return map;
+    }
+  }
+
+  public static void registerSerializers(Fury fury) {
+    fury.registerSerializer(List12, new ImmutableListSerializer(fury, List12));
+    fury.registerSerializer(ListN, new ImmutableListSerializer(fury, ListN));
+    fury.registerSerializer(SubList, new ImmutableListSerializer(fury, SubList));
+    fury.registerSerializer(Set12, new ImmutableSetSerializer(fury, Set12));
+    fury.registerSerializer(SetN, new ImmutableSetSerializer(fury, SetN));
+    fury.registerSerializer(Map1, new ImmutableMapSerializer(fury, Map1));
+    fury.registerSerializer(MapN, new ImmutableMapSerializer(fury, MapN));
+  }
+}

--- a/java/fury-core/src/main/java/io/fury/serializer/ImmutableCollectionSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/ImmutableCollectionSerializers.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.fury.serializer;
 
 import io.fury.Fury;

--- a/java/fury-core/src/main/java/io/fury/serializer/ImmutableCollectionSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/ImmutableCollectionSerializers.java
@@ -80,12 +80,19 @@ public class ImmutableCollectionSerializers {
     } else {
       // Use stub class as placeholder to ensure jdk8 registered id consistent with JDK9+.
       class List12Stub {}
+
       class ListNStub {}
+
       class SubListStub {}
+
       class Set12Stub {}
+
       class SetNStub {}
+
       class Map1Stub {}
+
       class MapNStub {}
+
       List12 = List12Stub.class;
       ListN = ListNStub.class;
       SubList = SubListStub.class;


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
The jdk9+ immutable collection is not registered and optimized in fury.

Currently users need to register those class by fury.register(List.of(1,2).getClass()) for serialization, or disable class registration by `FuryBuilder.requireClassRegistration(false)`, which is tedious.

More importantly , the serialization call writeReplace/readResolve to ensure jdk compatibilyty, which is not efficient.
And generics are not used either.

This PR optimize above all issues ,and support jit&generics optimization for such class.
<!-- Please give a short brief about these changes. -->.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #820 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
