### PR TITLE
[Java] optimize duplicate fields utils

### DIFF
--- a/java/fury-core/src/main/java/io/fury/builder/AccessorHelper.java
+++ b/java/fury-core/src/main/java/io/fury/builder/AccessorHelper.java
@@ -157,13 +157,10 @@ public class AccessorHelper {
         long startTime = System.nanoTime();
         String code = genCode(beanClass);
         long durationMs = (System.nanoTime() - startTime) / 1000_000;
-        startTime = System.nanoTime();
         LOG.info("Generate code {} take {} ms", qualifiedClassName, durationMs);
         String pkg = CodeGenerator.getPackage(beanClass);
         CompileUnit compileUnit = new CompileUnit(pkg, accessorClassName(beanClass), code);
         Map<String, byte[]> classByteCodes = JaninoUtils.toBytecode(classLoader, compileUnit);
-        durationMs = (System.nanoTime() - startTime) / 1000_000;
-        LOG.info("Compile {} take {} ms", qualifiedClassName, durationMs);
         boolean succeed =
             ClassLoaderUtils.tryDefineClassesInClassLoader(
                     qualifiedClassName,

--- a/java/fury-core/src/main/java/io/fury/builder/CodecBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/builder/CodecBuilder.java
@@ -100,8 +100,7 @@ public abstract class CodecBuilder {
     if (isRecord) {
       recordCtrAccessible = recordCtrAccessible(beanClass);
     }
-    duplicatedFields =
-        Descriptor.getSortedDuplicatedFields(Descriptor.getAllDescriptorsMap(beanClass)).keySet();
+    duplicatedFields = Descriptor.getSortedDuplicatedFields(beanClass).keySet();
     // don't ctx.addImport beanClass, because it maybe causes name collide.
     ctx.reserveName(FURY_NAME);
     ctx.reserveName(ROOT_OBJECT_NAME);

--- a/java/fury-core/src/main/java/io/fury/resolver/FieldResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/FieldResolver.java
@@ -46,6 +46,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -193,7 +194,12 @@ public class FieldResolver {
     // all fields of class and super classes should be a consistent order between jvm process.
     SortedMap<Field, Descriptor> allFieldsMap =
         fury.getClassResolver().getAllDescriptorsMap(type, resolveParent);
-    Set<String> duplicatedFields = Descriptor.getSortedDuplicatedFields(allFieldsMap).keySet();
+    Set<String> duplicatedFields;
+    if (resolveParent) {
+      duplicatedFields = Descriptor.getSortedDuplicatedFields(type).keySet();
+    } else {
+      duplicatedFields = new HashSet<>();
+    }
     List<ClassField> allFields =
         allFieldsMap.keySet().stream().map(ClassField::new).collect(Collectors.toList());
     return new FieldResolver(fury, type, ignoreCollectionType, allFields, duplicatedFields);


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
optimize duplicate fields utils by useing ClassValue cache to avoid recreate it every time in different threads
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
