### PR TITLE
[Java] Skip `toString` in annotation invocation handler `readObject`

### DIFF
--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -556,6 +556,12 @@ public class ClassResolver {
     if (Externalizable.class.isAssignableFrom(clz)) {
       return false;
     } else {
+      // `AnnotationInvocationHandler#readObject` may invoke `toString` of object, which may be risky.
+      // For example, JsonObject#toString may invoke `getter`.
+      // Use fury serialization to avoid this.
+      if ("sun.reflect.annotation.AnnotationInvocationHandler".equals(clz.getName())) {
+        return false;
+      }
       return JavaSerializer.getReadObjectMethod(clz) != null
           || JavaSerializer.getWriteObjectMethod(clz) != null;
     }

--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -556,7 +556,8 @@ public class ClassResolver {
     if (Externalizable.class.isAssignableFrom(clz)) {
       return false;
     } else {
-      // `AnnotationInvocationHandler#readObject` may invoke `toString` of object, which may be risky.
+      // `AnnotationInvocationHandler#readObject` may invoke `toString` of object, which may be
+      // risky.
       // For example, JsonObject#toString may invoke `getter`.
       // Use fury serialization to avoid this.
       if ("sun.reflect.annotation.AnnotationInvocationHandler".equals(clz.getName())) {


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Skip `toString` in annotation invocation handler `readObject` by fury serialization.

Disclaimer:
This `toString` can be invoked only when Fury class registration disabled. Please don't disable it if your environent is not safe.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
