### PR TITLE
[Java] use raw type serializer for getSerialzier in jit

### DIFF
--- a/java/fury-core/src/main/java/io/fury/builder/BaseObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/builder/BaseObjectCodecBuilder.java
@@ -499,7 +499,7 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
       // Don't invoke `Serializer.newSerializer` here, since it(ex. ObjectSerializer) may set itself
       // as global serializer, which overwrite serializer updates in jit callback.
       Expression newSerializerExpr =
-          inlineInvoke(classResolverRef, "getSerializer", SERIALIZER_TYPE, fieldTypeExpr);
+          inlineInvoke(classResolverRef, "getRawSerializer", SERIALIZER_TYPE, fieldTypeExpr);
       String name = ctx.newName(StringUtils.uncapitalize(serializerClass.getSimpleName()));
       // It's ok it jit already finished and this method return false, in such cases
       // `serializerClass` is already jit generated class.

--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Primitives;
 import com.google.common.reflect.TypeToken;
 import io.fury.Fury;
+import io.fury.annotation.CodegenInvoke;
 import io.fury.annotation.Internal;
 import io.fury.builder.CodecUtils;
 import io.fury.builder.Generated;
@@ -736,6 +737,17 @@ public class ClassResolver {
   public <T> Serializer<T> getSerializer(Class<T> cls) {
     Preconditions.checkNotNull(cls);
     return (Serializer<T>) getOrUpdateClassInfo(cls).serializer;
+  }
+
+  /**
+   * Return serializer without generics for specified class. The cast of Serializer to subclass
+   * serializer with generic is easy to raise compiler error for javac, so just use raw type.
+   */
+  @Internal
+  @CodegenInvoke
+  public Serializer<?> getRawSerializer(Class<?> cls) {
+    Preconditions.checkNotNull(cls);
+    return getOrUpdateClassInfo(cls).serializer;
   }
 
   public boolean isSerializable(Class<?> cls) {


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This pr uses raw type serializer for getSerialzier in jit. The cast of Serializer to subclass serializer with generic is easy to raise compiler error for javac, so just use raw type.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
