### PR TITLE
[Java] use varint for class id encoding to reduce space cost

### DIFF
--- a/java/fury-core/src/main/java/io/fury/Fury.java
+++ b/java/fury-core/src/main/java/io/fury/Fury.java
@@ -743,7 +743,7 @@ public final class Fury {
     int nextReadRefId = refResolver.tryPreserveRefId(buffer);
     if (nextReadRefId >= NOT_NULL_VALUE_FLAG) {
       // ref value or not-null value
-      Object o = readDataInternal(buffer, classResolver.readAndUpdateClassInfoHolder(buffer));
+      Object o = readDataInternal(buffer, classResolver.readClassInfo(buffer));
       refResolver.setReadObject(nextReadRefId, o);
       return o;
     } else {
@@ -788,7 +788,7 @@ public final class Fury {
 
   /** Deserialize not-null and non-reference object from <code>buffer</code>. */
   public Object readNonRef(MemoryBuffer buffer) {
-    return readDataInternal(buffer, classResolver.readAndUpdateClassInfoHolder(buffer));
+    return readDataInternal(buffer, classResolver.readClassInfo(buffer));
   }
 
   public Object readNonRef(MemoryBuffer buffer, ClassInfoHolder classInfoHolder) {

--- a/java/fury-core/src/main/java/io/fury/resolver/ClassInfo.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassInfo.java
@@ -37,6 +37,7 @@ public class ClassInfo {
   final EnumStringBytes typeTagBytes;
   Serializer<?> serializer;
   // use primitive to avoid boxing
+  // class id must be less than Integer.MAX_VALUE/2 since we use bit 0 as class id flag.
   short classId;
 
   ClassInfo(

--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -1500,7 +1500,10 @@ public class ClassResolver {
     }
   }
 
-  /** Read class info from java data <code>buffer</code>. */
+  /**
+   * Read class info from java data <code>buffer</code>. {@link #readClassInfo(MemoryBuffer,
+   * ClassInfo)} is faster since it use a non-global class info cache.
+   */
   public ClassInfo readClassInfo(MemoryBuffer buffer) {
     byte flag = buffer.readByte();
     if (flag == USE_CLASS_VALUE_FLAG) {
@@ -1522,7 +1525,10 @@ public class ClassResolver {
     }
   }
 
-  /** Read class info from java data <code>buffer</code>. */
+  /**
+   * Read class info from java data <code>buffer</code>. `classInfoCache` is used as a cache to
+   * reduce map lookup to load class from binary.
+   */
   @CodegenInvoke
   public ClassInfo readClassInfo(MemoryBuffer buffer, ClassInfo classInfoCache) {
     byte flag = buffer.readByte();

--- a/java/fury-core/src/main/java/io/fury/serializer/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/CollectionSerializers.java
@@ -1107,7 +1107,7 @@ public class CollectionSerializers {
 
     @Override
     public EnumSet read(MemoryBuffer buffer) {
-      Class elemClass = fury.getClassResolver().readClassAndUpdateCache(buffer);
+      Class elemClass = fury.getClassResolver().readClassInfo(buffer).getCls();
       EnumSet object = EnumSet.noneOf(elemClass);
       Serializer elemSerializer = fury.getClassResolver().getSerializer(elemClass);
       int length = buffer.readPositiveAlignedVarInt();

--- a/java/fury-core/src/main/java/io/fury/serializer/MapSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/MapSerializers.java
@@ -1040,7 +1040,7 @@ public class MapSerializers {
 
     @Override
     public EnumMap newMap(MemoryBuffer buffer, int numElements) {
-      Class<?> keyType = fury.getClassResolver().readClassAndUpdateCache(buffer);
+      Class<?> keyType = fury.getClassResolver().readClassInfo(buffer).getCls();
       return new EnumMap(keyType);
     }
   }

--- a/java/fury-core/src/main/java/io/fury/serializer/ReplaceResolveSerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/ReplaceResolveSerializer.java
@@ -268,7 +268,7 @@ public class ReplaceResolveSerializer extends Serializer {
       int nextReadRefId = refResolver.tryPreserveRefId(buffer);
       if (nextReadRefId >= Fury.NOT_NULL_VALUE_FLAG) {
         // ref value or not-null value
-        Object o = fury.readData(buffer, classResolver.readAndUpdateClassInfoHolder(buffer));
+        Object o = fury.readData(buffer, classResolver.readClassInfo(buffer));
         refResolver.setReadObject(nextReadRefId, o);
         refResolver.setReadObject(outerRefId, o);
         return o;

--- a/java/fury-core/src/main/java/io/fury/serializer/UnexistedClassSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/UnexistedClassSerializers.java
@@ -104,8 +104,8 @@ public final class UnexistedClassSerializers {
       // Register NotFoundClass ahead to skip write meta shared info,
       // then revert written class id to write class info here,
       // since it's the only place to hold class def for not found class.
-      buffer.increaseWriterIndex(-3);
-      buffer.writeByte(ClassResolver.USE_CLASS_VALUE);
+      buffer.increaseWriterIndex(-2);
+      buffer.writeByte(ClassResolver.USE_CLASS_VALUE_FLAG);
       MetaContext metaContext = fury.getSerializationContext().getMetaContext();
       IdentityObjectIntMap classMap = metaContext.classMap;
       int newId = classMap.size;

--- a/java/fury-core/src/test/java/io/fury/resolver/ClassResolverTest.java
+++ b/java/fury-core/src/test/java/io/fury/resolver/ClassResolverTest.java
@@ -221,8 +221,8 @@ public class ClassResolverTest extends FuryTestBase {
       MemoryBuffer buffer = MemoryUtils.buffer(32);
       classResolver.writeClassAndUpdateCache(buffer, getClass());
       classResolver.writeClassAndUpdateCache(buffer, getClass());
-      Assert.assertSame(classResolver.readClassAndUpdateCache(buffer), getClass());
-      Assert.assertSame(classResolver.readClassAndUpdateCache(buffer), getClass());
+      Assert.assertSame(classResolver.readClassInfo(buffer).getCls(), getClass());
+      Assert.assertSame(classResolver.readClassInfo(buffer).getCls(), getClass());
       classResolver.reset();
       buffer.writerIndex(0);
       buffer.readerIndex(0);


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR use varint for class id encoding to reduce java class writing space cost.

Before this PR, class id will be written as 3 bytes:
```java
| flag byte | two bytes short class id|
```

With this PR, class id will be written as 1~3 bytes, and for most common used jdk types such as String, class id will be written using 1 bytes, which is much more efficient.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #944

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
