### PR TITLE
[Java] Fix Collection/Map jit/interpreter protocol inconsisitency for generics instantiated subclass

### DIFF
--- a/java/fury-core/src/main/java/io/fury/serializer/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/CollectionSerializers.java
@@ -96,10 +96,10 @@ public class CollectionSerializers {
     // For subclass whose element type are instantiated already, such as
     // `Subclass extends ArrayList<String>`. If declared `Collection` doesn't specify
     // instantiated element type, then the serialization will need to write this element
-    // type again. Although we can extract this generics when creating this serializer,
+    // type. Although we can extract this generics when creating the serializer,
     // we can't do it when jit `Serializer` for some class which contains one of such collection
-    // field. So we will write this extra element class although it seems unnecessary to keep
-    // protocol consistency between interpreter and jit mode.
+    // field. So we will write this extra element class to keep protocol consistency between
+    // interpreter and jit mode although it seems unnecessary.
 
     public CollectionSerializer(Fury fury, Class<T> cls) {
       this(fury, cls, !ReflectionUtils.isDynamicGeneratedCLass(cls));

--- a/java/fury-core/src/main/java/io/fury/serializer/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/CollectionSerializers.java
@@ -81,9 +81,7 @@ public class CollectionSerializers {
     public static int NOT_SAME_TYPE = 0b1000;
   }
 
-  /**
-   * Serializer for {@link Collection}. All collection serializer should extend this class.
-   */
+  /** Serializer for {@link Collection}. All collection serializer should extend this class. */
   public static class CollectionSerializer<T extends Collection> extends Serializer<T> {
     private Constructor<?> constructor;
     private final boolean supportCodegenHook;

--- a/java/fury-core/src/main/java/io/fury/serializer/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/CollectionSerializers.java
@@ -16,8 +16,6 @@
 
 package io.fury.serializer;
 
-import static io.fury.type.TypeUtils.getRawType;
-
 import com.google.common.base.Preconditions;
 import io.fury.Fury;
 import io.fury.annotation.CodegenInvoke;
@@ -85,6 +83,7 @@ public class CollectionSerializers {
 
   /**
    * Serializer for {@link Collection}. All collection serializer should extend this class.
+   *
    * @param <T>
    */
   public static class CollectionSerializer<T extends Collection> extends Serializer<T> {
@@ -100,13 +99,13 @@ public class CollectionSerializers {
     // we can't do it when jit `Serializer` for some class which contains one of such collection
     // field. So we will write this extra element class to keep protocol consistency between
     // interpreter and jit mode although it seems unnecessary.
+    // With elements header, we can write this element class only once, the cost won't be too much.
 
     public CollectionSerializer(Fury fury, Class<T> cls) {
       this(fury, cls, !ReflectionUtils.isDynamicGeneratedCLass(cls));
     }
 
-    public CollectionSerializer(
-        Fury fury, Class<T> cls, boolean supportCodegenHook) {
+    public CollectionSerializer(Fury fury, Class<T> cls, boolean supportCodegenHook) {
       super(fury, cls);
       this.supportCodegenHook = supportCodegenHook;
       elementClassInfoHolder = fury.getClassResolver().nilClassInfoHolder();

--- a/java/fury-core/src/main/java/io/fury/serializer/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/CollectionSerializers.java
@@ -19,7 +19,6 @@ package io.fury.serializer;
 import static io.fury.type.TypeUtils.getRawType;
 
 import com.google.common.base.Preconditions;
-import com.google.common.reflect.TypeToken;
 import io.fury.Fury;
 import io.fury.annotation.CodegenInvoke;
 import io.fury.config.Language;
@@ -31,7 +30,6 @@ import io.fury.resolver.ClassResolver;
 import io.fury.resolver.RefResolver;
 import io.fury.type.GenericType;
 import io.fury.type.Type;
-import io.fury.type.TypeUtils;
 import io.fury.util.Platform;
 import io.fury.util.ReflectionUtils;
 import java.lang.reflect.Constructor;
@@ -85,46 +83,37 @@ public class CollectionSerializers {
     public static int NOT_SAME_TYPE = 0b1000;
   }
 
+  /**
+   * Serializer for {@link Collection}. All collection serializer should extend this class.
+   * @param <T>
+   */
   public static class CollectionSerializer<T extends Collection> extends Serializer<T> {
     private Constructor<?> constructor;
     private final boolean supportCodegenHook;
     // TODO remove elemSerializer, support generics in CompatibleSerializer.
     private Serializer<?> elemSerializer;
     protected final ClassInfoHolder elementClassInfoHolder;
-    // support subclass whose element type are instantiated already, such as
-    // `Subclass extends ArrayList<String>`.
-    // nested generics such as `Subclass extends ArrayList<List<Integer>>` can only be passed by
-    // `pushGenerics` instead of set element serializers.
-    private final GenericType collectionGenericType;
+    // For subclass whose element type are instantiated already, such as
+    // `Subclass extends ArrayList<String>`. If declared `Collection` doesn't specify
+    // instantiated element type, then the serialization will need to write this element
+    // type again. Although we can extract this generics when creating this serializer,
+    // we can't do it when jit `Serializer` for some class which contains one of such collection
+    // field. So we will write this extra element class although it seems unnecessary to keep
+    // protocol consistency between interpreter and jit mode.
 
     public CollectionSerializer(Fury fury, Class<T> cls) {
-      this(fury, cls, !ReflectionUtils.isDynamicGeneratedCLass(cls), true);
+      this(fury, cls, !ReflectionUtils.isDynamicGeneratedCLass(cls));
     }
 
     public CollectionSerializer(
-        Fury fury, Class<T> cls, boolean supportCodegenHook, boolean inferGenerics) {
+        Fury fury, Class<T> cls, boolean supportCodegenHook) {
       super(fury, cls);
       this.supportCodegenHook = supportCodegenHook;
       elementClassInfoHolder = fury.getClassResolver().nilClassInfoHolder();
-      if (inferGenerics) {
-        TypeToken<?> elementType = TypeUtils.getElementType(TypeToken.of(cls));
-        if (getRawType(elementType) != Object.class) {
-          collectionGenericType =
-              fury.getClassResolver()
-                  .buildGenericType(TypeUtils.collectionOf(elementType).getType());
-        } else {
-          collectionGenericType = null;
-        }
-      } else {
-        collectionGenericType = null;
-      }
     }
 
     private GenericType getElementGenericType(Fury fury) {
       GenericType genericType = fury.getGenerics().nextGenericType();
-      if (genericType == null || genericType.getTypeParametersCount() < 1) {
-        genericType = collectionGenericType;
-      }
       GenericType elemGenericType = null;
       if (genericType != null) {
         elemGenericType = genericType.getTypeParameter0();
@@ -735,7 +724,7 @@ public class CollectionSerializers {
 
   public static final class ArrayListSerializer extends CollectionSerializer<ArrayList> {
     public ArrayListSerializer(Fury fury) {
-      super(fury, ArrayList.class, true, false);
+      super(fury, ArrayList.class, true);
     }
 
     @Override
@@ -755,7 +744,7 @@ public class CollectionSerializers {
     private final long arrayFieldOffset;
 
     public ArraysAsListSerializer(Fury fury, Class<List<?>> cls) {
-      super(fury, cls, false, false);
+      super(fury, cls, false);
       try {
         Field arrayField = Class.forName("java.util.Arrays$ArrayList").getDeclaredField("a");
         arrayFieldOffset = ReflectionUtils.getFieldOffset(arrayField);
@@ -806,7 +795,7 @@ public class CollectionSerializers {
 
   public static final class HashSetSerializer extends CollectionSerializer<HashSet> {
     public HashSetSerializer(Fury fury) {
-      super(fury, HashSet.class, true, false);
+      super(fury, HashSet.class, true);
     }
 
     @Override
@@ -824,7 +813,7 @@ public class CollectionSerializers {
 
   public static final class LinkedHashSetSerializer extends CollectionSerializer<LinkedHashSet> {
     public LinkedHashSetSerializer(Fury fury) {
-      super(fury, LinkedHashSet.class, true, false);
+      super(fury, LinkedHashSet.class, true);
     }
 
     @Override
@@ -844,7 +833,7 @@ public class CollectionSerializers {
     private Constructor<?> constructor;
 
     public SortedSetSerializer(Fury fury, Class<T> cls) {
-      super(fury, cls, true, false);
+      super(fury, cls, true);
       if (cls != TreeSet.class) {
         try {
           this.constructor = cls.getConstructor(Comparator.class);
@@ -889,7 +878,7 @@ public class CollectionSerializers {
   public static final class EmptyListSerializer extends CollectionSerializer<List<?>> {
 
     public EmptyListSerializer(Fury fury, Class<List<?>> cls) {
-      super(fury, cls, false, false);
+      super(fury, cls, false);
     }
 
     @Override
@@ -921,7 +910,7 @@ public class CollectionSerializers {
   public static final class EmptySetSerializer extends CollectionSerializer<Set<?>> {
 
     public EmptySetSerializer(Fury fury, Class<Set<?>> cls) {
-      super(fury, cls, false, false);
+      super(fury, cls, false);
     }
 
     @Override
@@ -953,7 +942,7 @@ public class CollectionSerializers {
   public static final class EmptySortedSetSerializer extends CollectionSerializer<SortedSet<?>> {
 
     public EmptySortedSetSerializer(Fury fury, Class<SortedSet<?>> cls) {
-      super(fury, cls, false, false);
+      super(fury, cls, false);
     }
 
     @Override
@@ -969,7 +958,7 @@ public class CollectionSerializers {
       extends CollectionSerializer<List<?>> {
 
     public CollectionsSingletonListSerializer(Fury fury, Class<List<?>> cls) {
-      super(fury, cls, false, false);
+      super(fury, cls, false);
     }
 
     @Override
@@ -1003,7 +992,7 @@ public class CollectionSerializers {
   public static final class CollectionsSingletonSetSerializer extends CollectionSerializer<Set<?>> {
 
     public CollectionsSingletonSetSerializer(Fury fury, Class<Set<?>> cls) {
-      super(fury, cls, false, false);
+      super(fury, cls, false);
     }
 
     @Override
@@ -1053,7 +1042,7 @@ public class CollectionSerializers {
   public static final class VectorSerializer extends CollectionSerializer<Vector> {
 
     public VectorSerializer(Fury fury, Class<Vector> cls) {
-      super(fury, cls, true, false);
+      super(fury, cls, true);
     }
 
     @Override
@@ -1067,7 +1056,7 @@ public class CollectionSerializers {
   public static final class ArrayDequeSerializer extends CollectionSerializer<ArrayDeque> {
 
     public ArrayDequeSerializer(Fury fury, Class<ArrayDeque> cls) {
-      super(fury, cls, true, false);
+      super(fury, cls, true);
     }
 
     @Override
@@ -1082,7 +1071,7 @@ public class CollectionSerializers {
     public EnumSetSerializer(Fury fury, Class<EnumSet> type) {
       // getElementType(EnumSet.class) will be `E` without Enum as bound.
       // so no need to infer generics in init.
-      super(fury, type, false, false);
+      super(fury, type, false);
     }
 
     @Override
@@ -1139,7 +1128,7 @@ public class CollectionSerializers {
 
   public static class PriorityQueueSerializer extends CollectionSerializer<PriorityQueue> {
     public PriorityQueueSerializer(Fury fury, Class<PriorityQueue> cls) {
-      super(fury, cls, true, false);
+      super(fury, cls, true);
     }
 
     public void writeHeader(MemoryBuffer buffer, PriorityQueue value) {
@@ -1165,7 +1154,7 @@ public class CollectionSerializers {
     private Serializer<T> dataSerializer;
 
     public DefaultJavaCollectionSerializer(Fury fury, Class<T> cls) {
-      super(fury, cls, false, false);
+      super(fury, cls, false);
       Preconditions.checkArgument(
           fury.getLanguage() == Language.JAVA,
           "Python default collection serializer should use " + CollectionSerializer.class);
@@ -1196,7 +1185,7 @@ public class CollectionSerializers {
     private final Serializer serializer;
 
     public JDKCompatibleCollectionSerializer(Fury fury, Class<T> cls) {
-      super(fury, cls, false, false);
+      super(fury, cls, false);
       // Collection which defined `writeReplace` may use this serializer, so check replace/resolve
       // is necessary.
       Class<? extends Serializer> serializerType =
@@ -1227,7 +1216,7 @@ public class CollectionSerializers {
     Class arrayAsListClass = Arrays.asList(1, 2).getClass();
     fury.registerSerializer(arrayAsListClass, new ArraysAsListSerializer(fury, arrayAsListClass));
     fury.registerSerializer(
-        LinkedList.class, new CollectionSerializer(fury, LinkedList.class, true, false));
+        LinkedList.class, new CollectionSerializer(fury, LinkedList.class, true));
     fury.registerSerializer(HashSet.class, new HashSetSerializer(fury));
     fury.registerSerializer(LinkedHashSet.class, new LinkedHashSetSerializer(fury));
     fury.registerSerializer(TreeSet.class, new SortedSetSerializer<>(fury, TreeSet.class));

--- a/java/fury-core/src/main/java/io/fury/serializer/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/CollectionSerializers.java
@@ -83,8 +83,6 @@ public class CollectionSerializers {
 
   /**
    * Serializer for {@link Collection}. All collection serializer should extend this class.
-   *
-   * @param <T>
    */
   public static class CollectionSerializer<T extends Collection> extends Serializer<T> {
     private Constructor<?> constructor;

--- a/java/fury-core/src/main/java/io/fury/serializer/GuavaSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/GuavaSerializers.java
@@ -211,7 +211,7 @@ public class GuavaSerializers {
   abstract static class GuavaMapSerializer<T extends Map> extends MapSerializer<T> {
 
     public GuavaMapSerializer(Fury fury, Class<T> cls) {
-      super(fury, cls, true, false);
+      super(fury, cls, true);
       fury.getClassResolver().setSerializer(cls, this);
     }
 

--- a/java/fury-core/src/main/java/io/fury/serializer/GuavaSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/GuavaSerializers.java
@@ -50,7 +50,7 @@ public class GuavaSerializers {
   abstract static class GuavaCollectionSerializer<T extends Collection>
       extends CollectionSerializer<T> {
     public GuavaCollectionSerializer(Fury fury, Class<T> cls) {
-      super(fury, cls, true, false);
+      super(fury, cls, true);
       fury.getClassResolver().setSerializer(cls, this);
     }
 
@@ -183,7 +183,7 @@ public class GuavaSerializers {
       extends CollectionSerializer<T> {
 
     public ImmutableSortedSetSerializer(Fury fury, Class<T> cls) {
-      super(fury, cls, false, false);
+      super(fury, cls, false);
       fury.getClassResolver().setSerializer(cls, this);
     }
 

--- a/java/fury-core/src/main/java/io/fury/serializer/ImmutableCollectionSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/ImmutableCollectionSerializers.java
@@ -105,7 +105,7 @@ public class ImmutableCollectionSerializers {
 
   public static class ImmutableListSerializer extends CollectionSerializers.CollectionSerializer {
     public ImmutableListSerializer(Fury fury, Class cls) {
-      super(fury, cls, true, false);
+      super(fury, cls, true);
     }
 
     @Override
@@ -136,7 +136,7 @@ public class ImmutableCollectionSerializers {
 
   public static class ImmutableSetSerializer extends CollectionSerializers.CollectionSerializer {
     public ImmutableSetSerializer(Fury fury, Class cls) {
-      super(fury, cls, true, false);
+      super(fury, cls, true);
     }
 
     @Override

--- a/java/fury-core/src/main/java/io/fury/serializer/ImmutableCollectionSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/ImmutableCollectionSerializers.java
@@ -167,7 +167,7 @@ public class ImmutableCollectionSerializers {
 
   public static class ImmutableMapSerializer extends MapSerializers.MapSerializer {
     public ImmutableMapSerializer(Fury fury, Class cls) {
-      super(fury, cls, true, false);
+      super(fury, cls, true);
     }
 
     @Override

--- a/java/fury-core/src/main/java/io/fury/serializer/MapSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/MapSerializers.java
@@ -17,7 +17,6 @@
 package io.fury.serializer;
 
 import static io.fury.type.TypeUtils.MAP_TYPE;
-import static io.fury.type.TypeUtils.getRawType;
 
 import com.google.common.base.Preconditions;
 import com.google.common.reflect.TypeToken;
@@ -82,13 +81,13 @@ public class MapSerializers {
     // we can't do it when jit `Serializer` for some class which contains one of such map
     // field. So we will write those extra kv classes to keep protocol consistency between
     // interpreter and jit mode although it seems unnecessary.
+    // With kv header in future, we can write this kv classes only once, the cost won't be too much.
 
     public MapSerializer(Fury fury, Class<T> cls) {
       this(fury, cls, !ReflectionUtils.isDynamicGeneratedCLass(cls));
     }
 
-    public MapSerializer(
-        Fury fury, Class<T> cls, boolean supportCodegenHook) {
+    public MapSerializer(Fury fury, Class<T> cls, boolean supportCodegenHook) {
       super(fury, cls);
       this.supportCodegenHook = supportCodegenHook;
       keyClassInfoWriteCache = fury.getClassResolver().nilClassInfoHolder();

--- a/java/fury-core/src/main/java/io/fury/serializer/SynchronizedSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/SynchronizedSerializers.java
@@ -78,7 +78,7 @@ public class SynchronizedSerializers {
     private final long offset;
 
     public SynchronizedCollectionSerializer(Fury fury, Class cls, Function factory, long offset) {
-      super(fury, cls, false, false);
+      super(fury, cls, false);
       this.factory = factory;
       this.offset = offset;
     }

--- a/java/fury-core/src/main/java/io/fury/serializer/SynchronizedSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/SynchronizedSerializers.java
@@ -104,7 +104,7 @@ public class SynchronizedSerializers {
     private final long offset;
 
     public SynchronizedMapSerializer(Fury fury, Class cls, Function factory, long offset) {
-      super(fury, cls, false, false);
+      super(fury, cls, false);
       this.factory = factory;
       this.offset = offset;
     }

--- a/java/fury-core/src/main/java/io/fury/serializer/UnmodifiableSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/UnmodifiableSerializers.java
@@ -74,7 +74,7 @@ public class UnmodifiableSerializers {
     private final long offset;
 
     public UnmodifiableCollectionSerializer(Fury fury, Class cls, Function factory, long offset) {
-      super(fury, cls, false, false);
+      super(fury, cls, false);
       this.factory = factory;
       this.offset = offset;
     }

--- a/java/fury-core/src/main/java/io/fury/serializer/UnmodifiableSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/UnmodifiableSerializers.java
@@ -98,7 +98,7 @@ public class UnmodifiableSerializers {
     private final long offset;
 
     public UnmodifiableMapSerializer(Fury fury, Class cls, Function factory, long offset) {
-      super(fury, cls, false, false);
+      super(fury, cls, false);
       this.factory = factory;
       this.offset = offset;
     }

--- a/java/fury-core/src/test/java/io/fury/serializer/CollectionSerializersTest.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/CollectionSerializersTest.java
@@ -485,7 +485,7 @@ public class CollectionSerializersTest extends FuryTestBase {
   public static class SubListSerializer extends CollectionSerializers.CollectionSerializer {
 
     public SubListSerializer(Fury fury, Class cls) {
-      super(fury, cls, true, false);
+      super(fury, cls, true);
     }
 
     @Override


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR fixed Collection/Map jit/interpreter protocol inconsisitency for generics instantiated subclass by remove auto generics infer for  Collection/Map subclass.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #946

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
