### PR TITLE
[Java] add serializeJavaObject API to ThreadSafeFury

### DIFF
--- a/java/fury-core/src/main/java/io/fury/ThreadLocalFury.java
+++ b/java/fury-core/src/main/java/io/fury/ThreadLocalFury.java
@@ -65,6 +65,11 @@ public class ThreadLocalFury implements ThreadSafeFury {
     return buffer.getBytes(0, buffer.writerIndex());
   }
 
+  @Override
+  public MemoryBuffer serialize(Object obj, long address, int size) {
+    return bindingThreadLocal.get().get().serialize(obj, address, size);
+  }
+
   public MemoryBuffer serialize(MemoryBuffer buffer, Object obj) {
     return bindingThreadLocal.get().get().serialize(buffer, obj);
   }
@@ -83,6 +88,26 @@ public class ThreadLocalFury implements ThreadSafeFury {
 
   public Object deserialize(ByteBuffer byteBuffer) {
     return bindingThreadLocal.get().get().deserialize(MemoryUtils.wrap(byteBuffer));
+  }
+
+  @Override
+  public byte[] serializeJavaObject(Object obj) {
+    return bindingThreadLocal.get().get().serializeJavaObject(obj);
+  }
+
+  @Override
+  public void serializeJavaObject(MemoryBuffer buffer, Object obj) {
+    bindingThreadLocal.get().get().serializeJavaObject(buffer, obj);
+  }
+
+  @Override
+  public <T> T deserializeJavaObject(byte[] data, Class<T> cls) {
+    return bindingThreadLocal.get().get().deserializeJavaObject(data, cls);
+  }
+
+  @Override
+  public <T> T deserializeJavaObject(MemoryBuffer buffer, Class<T> cls) {
+    return bindingThreadLocal.get().get().deserializeJavaObject(buffer, cls);
   }
 
   public void setClassLoader(ClassLoader classLoader) {

--- a/java/fury-core/src/main/java/io/fury/ThreadSafeFury.java
+++ b/java/fury-core/src/main/java/io/fury/ThreadSafeFury.java
@@ -35,17 +35,56 @@ public interface ThreadSafeFury {
    */
   <R> R execute(Function<Fury, R> action);
 
+  /** Return serialized <code>obj</code> as a byte array. */
   byte[] serialize(Object obj);
 
+  /**
+   * Serialize <code>obj</code> to a off-heap buffer specified by <code>address</code> and <code>
+   * size</code>.
+   */
+  MemoryBuffer serialize(Object obj, long address, int size);
+
+  /** Serialize data into buffer. */
   MemoryBuffer serialize(MemoryBuffer buffer, Object obj);
 
+  /** Deserialize <code>obj</code> from a byte array. */
   Object deserialize(byte[] bytes);
 
+  /**
+   * Deserialize <code>obj</code> from a off-heap buffer specified by <code>address</code> and
+   * <code>size</code>.
+   */
   Object deserialize(long address, int size);
 
+  /** Deserialize <code>obj</code> from a <code>buffer</code>. */
   Object deserialize(MemoryBuffer buffer);
 
+  /** Deserialize <code>obj</code> from a {@link ByteBuffer}. */
   Object deserialize(ByteBuffer byteBuffer);
+
+  /**
+   * Serialize java object without class info, deserialization should use {@link
+   * #deserializeJavaObject}.
+   */
+  byte[] serializeJavaObject(Object obj);
+
+  /**
+   * Serialize java object without class info, deserialization should use {@link
+   * #deserializeJavaObject}.
+   */
+  void serializeJavaObject(MemoryBuffer buffer, Object obj);
+
+  /**
+   * Deserialize java object from binary without class info, serialization should use {@link
+   * #serializeJavaObject}.
+   */
+  <T> T deserializeJavaObject(byte[] data, Class<T> cls);
+
+  /**
+   * Deserialize java object from binary by passing class info, serialization should use {@link
+   * #serializeJavaObject}.
+   */
+  <T> T deserializeJavaObject(MemoryBuffer buffer, Class<T> cls);
 
   /**
    * Set classLoader of serializer for current thread only.

--- a/java/fury-core/src/main/java/io/fury/pool/ThreadPoolFury.java
+++ b/java/fury-core/src/main/java/io/fury/pool/ThreadPoolFury.java
@@ -61,6 +61,17 @@ public class ThreadPoolFury implements ThreadSafeFury {
     }
   }
 
+  @Override
+  public MemoryBuffer serialize(Object obj, long address, int size) {
+    Fury fury = null;
+    try {
+      fury = furyPooledObjectFactory.getFury();
+      return fury.serialize(obj, address, size);
+    } finally {
+      furyPooledObjectFactory.returnFury(fury);
+    }
+  }
+
   public MemoryBuffer serialize(MemoryBuffer buffer, Object obj) {
     Fury fury = null;
     try {
@@ -106,6 +117,50 @@ public class ThreadPoolFury implements ThreadSafeFury {
     try {
       fury = furyPooledObjectFactory.getFury();
       return fury.deserialize(MemoryUtils.wrap(byteBuffer));
+    } finally {
+      furyPooledObjectFactory.returnFury(fury);
+    }
+  }
+
+  @Override
+  public byte[] serializeJavaObject(Object obj) {
+    Fury fury = null;
+    try {
+      fury = furyPooledObjectFactory.getFury();
+      return fury.serializeJavaObject(obj);
+    } finally {
+      furyPooledObjectFactory.returnFury(fury);
+    }
+  }
+
+  @Override
+  public void serializeJavaObject(MemoryBuffer buffer, Object obj) {
+    Fury fury = null;
+    try {
+      fury = furyPooledObjectFactory.getFury();
+      fury.serializeJavaObject(buffer, obj);
+    } finally {
+      furyPooledObjectFactory.returnFury(fury);
+    }
+  }
+
+  @Override
+  public <T> T deserializeJavaObject(byte[] data, Class<T> cls) {
+    Fury fury = null;
+    try {
+      fury = furyPooledObjectFactory.getFury();
+      return fury.deserializeJavaObject(data, cls);
+    } finally {
+      furyPooledObjectFactory.returnFury(fury);
+    }
+  }
+
+  @Override
+  public <T> T deserializeJavaObject(MemoryBuffer buffer, Class<T> cls) {
+    Fury fury = null;
+    try {
+      fury = furyPooledObjectFactory.getFury();
+      return fury.deserializeJavaObject(buffer, cls);
     } finally {
       furyPooledObjectFactory.returnFury(fury);
     }

--- a/java/fury-core/src/test/java/io/fury/ThreadSafeFuryTest.java
+++ b/java/fury-core/src/test/java/io/fury/ThreadSafeFuryTest.java
@@ -21,6 +21,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import io.fury.config.Language;
+import io.fury.memory.MemoryBuffer;
 import io.fury.resolver.MetaContext;
 import io.fury.serializer.Serializer;
 import io.fury.test.bean.BeanA;
@@ -262,5 +263,20 @@ public class ThreadSafeFuryTest extends FuryTestBase {
       fury.clearClassLoader(structClass2.getClassLoader());
     }
     return map;
+  }
+
+  @Test
+  public void testSerializeJavaObject() {
+    for (ThreadSafeFury fury :
+        new ThreadSafeFury[] {
+          Fury.builder().requireClassRegistration(false).buildThreadSafeFury(),
+          Fury.builder().requireClassRegistration(false).buildThreadSafeFuryPool(2, 2)
+        }) {
+      byte[] bytes = fury.serializeJavaObject("abc");
+      Assert.assertEquals(fury.deserializeJavaObject(bytes, String.class), "abc");
+      MemoryBuffer buffer = MemoryBuffer.newHeapBuffer(8);
+      fury.serializeJavaObject(buffer, "abc");
+      Assert.assertEquals(fury.deserializeJavaObject(buffer, String.class), "abc");
+    }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR added serializeJavaObject API to ThreadSafeFury to improve the usability of `ThreadSafeFury`.

Before this pr, users need to use :
```
io.fury.ThreadSafeFury#execute(f - > f.serializeJavaObject())
```
which is a little inconvenient. Now users can just use `ThreadSafeFury#serializeJavaObject` directly.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
