### PR TITLE
[Go] Make compilation support tinygo

### DIFF
--- a/go/fury/type.go
+++ b/go/fury/type.go
@@ -136,9 +136,11 @@ const (
 )
 
 var (
-	interfaceType      = reflect.TypeOf((*interface{})(nil)).Elem()
-	stringType         = reflect.TypeOf((*string)(nil)).Elem()
-	stringPtrType      = reflect.TypeOf((**string)(nil)).Elem()
+	interfaceType = reflect.TypeOf((*interface{})(nil)).Elem()
+	stringType    = reflect.TypeOf((*string)(nil)).Elem()
+	// Make compilation support tinygo
+	stringPtrType = reflect.TypeOf((*string)(nil))
+	//stringPtrType      = reflect.TypeOf((**string)(nil)).Elem()
 	stringSliceType    = reflect.TypeOf((*[]string)(nil)).Elem()
 	byteSliceType      = reflect.TypeOf((*[]byte)(nil)).Elem()
 	boolSliceType      = reflect.TypeOf((*[]bool)(nil)).Elem()


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
`stringPtrType = reflect.TypeOf((**string)(nil)).Elem()` will cause tinygo compilation error, this pr change it to:
```stringPtrType = reflect.TypeOf((*string)(nil))```
