### PR TITLE
[go] fixed typo in readme import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ print(fury.deserialize(data))
 ```go
 package main
 
-import furygo "github.com/alipay/fury/fury/go/fury"
+import furygo "github.com/alipay/fury/go/fury"
 import "fmt"
 
 func main() {


### PR DESCRIPTION
## What do these changes do?

The import path in the Go example is incorrect, updated it to the correct one.

Updated example: https://go.dev/play/p/a1I6Z49hzHl
Old example: https://go.dev/play/p/6D9YmHFwdpV
Error with old example:
```
go: finding module for package github.com/alipay/fury/fury/go/fury
go: downloading github.com/alipay/fury v0.2.0
main.go:3:8: module github.com/alipay/fury@latest found (v0.2.0), but does not contain package github.com/alipay/fury/fury/go/fury
```

## Related issue number
(didn't open an issue, since this is so minor)

## Check code requirements

