### PR TITLE
[Java] rename wrong ascii naming to latin

### DIFF
--- a/docs/protocols/java_object_graph.md
+++ b/docs/protocols/java_object_graph.md
@@ -42,13 +42,13 @@ The data are serialized using little endian order overall.
 
 ## String
 Format:
-- one byte for encoding: 0 for `ascii`, 1 for `utf-16`, 2 for `utf-8`.
+- one byte for encoding: 0 for `latin`, 1 for `utf-16`, 2 for `utf-8`.
 - positive varint for encoded string binary length.
-- encoded string binary data based on encoding: `ascii/utf-16/utf-8`.
+- encoded string binary data based on encoding: `latin/utf-16/utf-8`.
 
 Which encoding to choose:
-- For JDK8: fury detect `ascii` at runtime, if string is `ascii` string, then use `ascii` encoding, otherwise use `utf-16`.
-- For JDK9+: fury use `coder` in `String` object for encoding, `ascii`/`utf-16` will be used for encoding.
+- For JDK8: fury detect `latin` at runtime, if string is `latin` string, then use `latin` encoding, otherwise use `utf-16`.
+- For JDK9+: fury use `coder` in `String` object for encoding, `latin`/`utf-16` will be used for encoding.
 - If the string is encoded by `utf-8`, then fury will use `utf-8` to decode the data. But currently fury doesn't enable utf-8 encoding by default for java. Cross-language string serialization of fury use `utf-8` by default.
 
 ## Array

--- a/java/fury-benchmark/src/main/java/io/fury/benchmark/CompressStringSuite.java
+++ b/java/fury-benchmark/src/main/java/io/fury/benchmark/CompressStringSuite.java
@@ -85,21 +85,21 @@ public class CompressStringSuite {
   }
 
   @Benchmark
-  public Object asciiScalarCheck() {
+  public Object latinScalarCheck() {
     char[] chars = latinStrChars;
-    boolean isAscii = true;
+    boolean isLatin = true;
     for (char c : chars) {
       if (c > 0xFF) {
-        isAscii = false;
+        isLatin = false;
         break;
       }
     }
-    return isAscii;
+    return isLatin;
   }
 
   @Benchmark
-  public Object asciiSuperWordCheck() {
-    return StringSerializer.isAscii(latinStrChars);
+  public Object latinSuperWordCheck() {
+    return StringSerializer.isLatin(latinStrChars);
   }
 
   public static void main(String[] args) throws Exception {
@@ -107,7 +107,7 @@ public class CompressStringSuite {
     System.out.printf("latinStrChars length %s\n", latinStrChars.length);
     if (args.length == 0) {
       String commandLine =
-          "io.*CompressStringSuite.ascii* -f 1 -wi 3 -i 3 -t 1 -w 2s -r 2s -rf csv";
+          "io.*CompressStringSuite.latin* -f 1 -wi 3 -i 3 -t 1 -w 2s -r 2s -rf csv";
       System.out.println(commandLine);
       args = commandLine.split(" ");
     }

--- a/java/fury-core/src/main/java/io/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/Serializers.java
@@ -235,8 +235,8 @@ public class Serializers {
         }
       } else {
         char[] v = (char[]) getValue.apply(value);
-        if (StringSerializer.isAscii(v)) {
-          stringSerializer.writeJDK8Ascii(buffer, v, value.length());
+        if (StringSerializer.isLatin(v)) {
+          stringSerializer.writeJDK8Latin(buffer, v, value.length());
         } else {
           stringSerializer.writeJDK8UTF16(buffer, v, value.length());
         }

--- a/java/fury-core/src/test/java/io/fury/serializer/StringSerializerTest.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/StringSerializerTest.java
@@ -288,19 +288,19 @@ public class StringSerializerTest extends FuryTestBase {
   }
 
   @Test(dataProvider = "endian")
-  public void testVectorizedAsciiCheckAlgorithm(boolean endian) {
-    // assertTrue(isAscii("Fury".toCharArray(), endian));
-    // assertTrue(isAscii(StringUtils.random(8 * 10).toCharArray(), endian));
+  public void testVectorizedLatinCheckAlgorithm(boolean endian) {
+    // assertTrue(isLatin("Fury".toCharArray(), endian));
+    // assertTrue(isLatin(StringUtils.random(8 * 10).toCharArray(), endian));
     // test unaligned
-    assertTrue(isAscii((StringUtils.random(8 * 10) + "1").toCharArray(), endian));
-    assertTrue(isAscii((StringUtils.random(8 * 10) + "12").toCharArray(), endian));
-    assertTrue(isAscii((StringUtils.random(8 * 10) + "123").toCharArray(), endian));
-    assertFalse(isAscii("你好, Fury".toCharArray(), endian));
-    assertFalse(isAscii((StringUtils.random(8 * 10) + "你好").toCharArray(), endian));
-    assertFalse(isAscii((StringUtils.random(8 * 10) + "1你好").toCharArray(), endian));
+    assertTrue(isLatin((StringUtils.random(8 * 10) + "1").toCharArray(), endian));
+    assertTrue(isLatin((StringUtils.random(8 * 10) + "12").toCharArray(), endian));
+    assertTrue(isLatin((StringUtils.random(8 * 10) + "123").toCharArray(), endian));
+    assertFalse(isLatin("你好, Fury".toCharArray(), endian));
+    assertFalse(isLatin((StringUtils.random(8 * 10) + "你好").toCharArray(), endian));
+    assertFalse(isLatin((StringUtils.random(8 * 10) + "1你好").toCharArray(), endian));
   }
 
-  private boolean isAscii(char[] chars, boolean isLittle) {
+  private boolean isLatin(char[] chars, boolean isLittle) {
     boolean reverseBytes =
         (Platform.IS_LITTLE_ENDIAN && !isLittle) || (!Platform.IS_LITTLE_ENDIAN && !isLittle);
     if (reverseBytes) {
@@ -310,62 +310,62 @@ public class StringSerializerTest extends FuryTestBase {
     }
     long mask;
     if (isLittle) {
-      // ascii chars will be 0xXX,0x00;0xXX,0x00 in byte order;
-      // Using 0x00,0xff(0xff00) to clear ascii bits.
+      // latin chars will be 0xXX,0x00;0xXX,0x00 in byte order;
+      // Using 0x00,0xff(0xff00) to clear latin bits.
       mask = 0xff00ff00ff00ff00L;
     } else {
-      // ascii chars will be 0x00,0xXX;0x00,0xXX in byte order;
-      // Using 0x00,0xff(0x00ff) to clear ascii bits.
+      // latin chars will be 0x00,0xXX;0x00,0xXX in byte order;
+      // Using 0x00,0xff(0x00ff) to clear latin bits.
       mask = 0x00ff00ff00ff00ffL;
     }
     int numChars = chars.length;
     int vectorizedLen = numChars >> 2;
     int vectorizedChars = vectorizedLen << 2;
     int endOffset = Platform.CHAR_ARRAY_OFFSET + (vectorizedChars << 1);
-    boolean isAscii = true;
+    boolean isLatin = true;
     for (int offset = Platform.CHAR_ARRAY_OFFSET; offset < endOffset; offset += 8) {
       // check 4 chars in a vectorized way, 4 times faster than scalar check loop.
       long multiChars = Platform.getLong(chars, offset);
       if ((multiChars & mask) != 0) {
-        isAscii = false;
+        isLatin = false;
         break;
       }
     }
-    if (isAscii) {
+    if (isLatin) {
       for (int i = vectorizedChars; i < numChars; i++) {
         char c = chars[i];
         if (reverseBytes) {
           c = Character.reverseBytes(c);
         }
         if (c > 0xFF) {
-          isAscii = false;
+          isLatin = false;
           break;
         }
       }
     }
-    return isAscii;
+    return isLatin;
   }
 
   @Test
-  public void testAsciiCheck() {
-    assertTrue(StringSerializer.isAscii("Fury".toCharArray()));
-    assertTrue(StringSerializer.isAscii(StringUtils.random(8 * 10).toCharArray()));
+  public void testLatinCheck() {
+    assertTrue(StringSerializer.isLatin("Fury".toCharArray()));
+    assertTrue(StringSerializer.isLatin(StringUtils.random(8 * 10).toCharArray()));
     // test unaligned
-    assertTrue(StringSerializer.isAscii((StringUtils.random(8 * 10) + "1").toCharArray()));
-    assertTrue(StringSerializer.isAscii((StringUtils.random(8 * 10) + "12").toCharArray()));
-    assertTrue(StringSerializer.isAscii((StringUtils.random(8 * 10) + "123").toCharArray()));
-    assertFalse(StringSerializer.isAscii("你好, Fury".toCharArray()));
-    assertFalse(StringSerializer.isAscii((StringUtils.random(8 * 10) + "你好").toCharArray()));
-    assertFalse(StringSerializer.isAscii((StringUtils.random(8 * 10) + "1你好").toCharArray()));
-    assertFalse(StringSerializer.isAscii((StringUtils.random(11) + "你").toCharArray()));
-    assertFalse(StringSerializer.isAscii((StringUtils.random(10) + "你好").toCharArray()));
-    assertFalse(StringSerializer.isAscii((StringUtils.random(9) + "性能好").toCharArray()));
-    assertFalse(StringSerializer.isAscii("\u1234".toCharArray()));
-    assertFalse(StringSerializer.isAscii("a\u1234".toCharArray()));
-    assertFalse(StringSerializer.isAscii("ab\u1234".toCharArray()));
-    assertFalse(StringSerializer.isAscii("abc\u1234".toCharArray()));
-    assertFalse(StringSerializer.isAscii("abcd\u1234".toCharArray()));
-    assertFalse(StringSerializer.isAscii("Javaone Keynote\u1234".toCharArray()));
+    assertTrue(StringSerializer.isLatin((StringUtils.random(8 * 10) + "1").toCharArray()));
+    assertTrue(StringSerializer.isLatin((StringUtils.random(8 * 10) + "12").toCharArray()));
+    assertTrue(StringSerializer.isLatin((StringUtils.random(8 * 10) + "123").toCharArray()));
+    assertFalse(StringSerializer.isLatin("你好, Fury".toCharArray()));
+    assertFalse(StringSerializer.isLatin((StringUtils.random(8 * 10) + "你好").toCharArray()));
+    assertFalse(StringSerializer.isLatin((StringUtils.random(8 * 10) + "1你好").toCharArray()));
+    assertFalse(StringSerializer.isLatin((StringUtils.random(11) + "你").toCharArray()));
+    assertFalse(StringSerializer.isLatin((StringUtils.random(10) + "你好").toCharArray()));
+    assertFalse(StringSerializer.isLatin((StringUtils.random(9) + "性能好").toCharArray()));
+    assertFalse(StringSerializer.isLatin("\u1234".toCharArray()));
+    assertFalse(StringSerializer.isLatin("a\u1234".toCharArray()));
+    assertFalse(StringSerializer.isLatin("ab\u1234".toCharArray()));
+    assertFalse(StringSerializer.isLatin("abc\u1234".toCharArray()));
+    assertFalse(StringSerializer.isLatin("abcd\u1234".toCharArray()));
+    assertFalse(StringSerializer.isLatin("Javaone Keynote\u1234".toCharArray()));
   }
 
   @Test

--- a/java/fury-format/README.md
+++ b/java/fury-format/README.md
@@ -2,7 +2,7 @@
 Fury row format is heavily inspired by spark tungsten row format, but with changes:
 - Use arrow schema to describe meta.
 - The implementation support java/C++/python/etc..
-- String support ascii/utf16/utf8 encoding.
+- String support latin/utf16/utf8 encoding.
 - Decimal use arrow decimal format.
 - Variable-size field can be inline in fixed-size region if small enough.
 - Allow skip padding by generate Row using aot to put offsets in generated code.

--- a/java/fury-format/src/main/java/io/fury/format/row/Row.java
+++ b/java/fury-format/src/main/java/io/fury/format/row/Row.java
@@ -21,7 +21,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 /**
  * Interface for row in row format. Row is inspired by Apache Spark tungsten, the differences are
  * <li>Use arrow schema to describe meta.
- * <li>String support ascii/utf16/utf8 encoding.
+ * <li>String support latin/utf16/utf8 encoding.
  * <li>Decimal use arrow decimal format.
  * <li>Variable-size field can be inline in fixed-size region if small enough.
  * <li>Allow skip padding bye generate Row using aot to put offsets in generated code.

--- a/java/fury-format/src/main/java/io/fury/format/row/binary/BinaryRow.java
+++ b/java/fury-format/src/main/java/io/fury/format/row/binary/BinaryRow.java
@@ -49,7 +49,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
  * <ul>
  *   BinaryRow is inspired by Apache Spark tungsten UnsafeRow, the differences are
  *   <li>Use arrow schema to describe meta.
- *   <li>String support ascii/utf16/utf8 encoding.
+ *   <li>String support latin/utf16/utf8 encoding.
  *   <li>Decimal use arrow decimal format.
  *   <li>Variable-size field can be inline in fixed-size region if small enough.
  *   <li>Allow skip padding by generate Row using aot to put offsets in generated code.


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Fury use latin/utf 16 for string encoding ,but we named it to ascii. We updated to latin in furyjs, but forget to update it for java. This pr fix it by replacing it from ascii to latin
<!-- Please give a short brief about these changes. -->s

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

https://github.com/eishay/jvm-serializers/pull/89#issuecomment-1768633760

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
