### PR TITLE
bugfix: read buffer error when object contain binary field

### DIFF
--- a/javascript/packages/fury/lib/reader.ts
+++ b/javascript/packages/fury/lib/reader.ts
@@ -114,6 +114,7 @@ export const BinaryReader = (config: Config) => {
   function binary(len: number) {
     const result = alloc(len);
     buffer.copy(result, 0, cursor, cursor + len);
+    cursor += len;
     return result;
   }
 

--- a/javascript/packages/fury/package.json
+++ b/javascript/packages/fury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@furyjs/fury",
-  "version": "0.3.0.dev",
+  "version": "0.3.0-beta.1",
   "description": "A blazing fast multi-language serialization framework powered by jit and zero-copy",
   "main": "dist/index.js",
   "scripts": {

--- a/javascript/packages/hps/package.json
+++ b/javascript/packages/hps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@furyjs/hps",
-  "version": "0.3.0.dev",
+  "version": "0.3.0-beta.1",
   "description": "fury nodejs high-performance suite",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

1. upgrade npm package version
2. move cursor when read binary field

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
 #1025 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
