### PR TITLE
[Java] Allow for `InputStream` not reading entire length

### DIFF
--- a/java/fury-core/src/main/java/io/fury/Fury.java
+++ b/java/fury-core/src/main/java/io/fury/Fury.java
@@ -707,7 +707,14 @@ public final class Fury {
       Preconditions.checkArgument(read == 4);
       int size = buffer.readInt();
       buffer.ensure(size + 4);
-      read = inputStream.read(buffer.getHeapMemory(), 4, size);
+      read = 0;
+      while (read < size) {
+        int count;
+        if ((count = inputStream.read(buffer.getHeapMemory(), read + 4, size - read)) == -1) {
+          break;
+        }
+        read += count;
+      }
       Preconditions.checkArgument(read == size);
       return deserialize(buffer, outOfBandBuffers);
     } catch (IOException e) {
@@ -1132,7 +1139,14 @@ public final class Fury {
         Preconditions.checkArgument(read == 4);
         int size = buffer.readInt();
         buffer.ensure(4 + size);
-        read = inputStream.read(buffer.getHeapMemory(), 4, size);
+        read = 0;
+        while (read < size) {
+          int count;
+          if ((count = inputStream.read(buffer.getHeapMemory(), read + 4, size - read)) == -1) {
+            break;
+          }
+          read += count;
+        }
         Preconditions.checkArgument(read == size);
       }
       Object o = function.apply(buffer);

--- a/java/fury-core/src/main/java/io/fury/Fury.java
+++ b/java/fury-core/src/main/java/io/fury/Fury.java
@@ -702,7 +702,7 @@ public final class Fury {
 
   public Object deserialize(InputStream inputStream, Iterable<MemoryBuffer> outOfBandBuffers) {
     try {
-      transferObjectFromStream(inputStream, buffer);
+      readToBufferFromStream(inputStream, buffer);
       return deserialize(buffer, outOfBandBuffers);
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -1122,7 +1122,7 @@ public final class Fury {
         MemoryUtils.wrap((ByteArrayInputStream) inputStream, buffer);
         buffer.increaseReaderIndex(4); // skip size.
       } else {
-        transferObjectFromStream(inputStream, buffer);
+        readToBufferFromStream(inputStream, buffer);
       }
       Object o = function.apply(buffer);
       if (isBis) {
@@ -1135,7 +1135,7 @@ public final class Fury {
     }
   }
 
-  private static void transferObjectFromStream(InputStream inputStream, MemoryBuffer buffer)
+  private static void readToBufferFromStream(InputStream inputStream, MemoryBuffer buffer)
       throws IOException {
     buffer.readerIndex(0);
     int read = inputStream.read(buffer.getHeapMemory(), 0, 4);

--- a/java/fury-core/src/main/java/io/fury/Fury.java
+++ b/java/fury-core/src/main/java/io/fury/Fury.java
@@ -701,7 +701,6 @@ public final class Fury {
   }
 
   public Object deserialize(InputStream inputStream, Iterable<MemoryBuffer> outOfBandBuffers) {
-    buffer.readerIndex(0);
     try {
       transferObjectFromStream(inputStream, buffer);
       return deserialize(buffer, outOfBandBuffers);
@@ -1114,11 +1113,11 @@ public final class Fury {
 
   private Object deserializeFromStream(
       InputStream inputStream, Function<MemoryBuffer, Object> function) {
-    buffer.readerIndex(0);
     try {
       boolean isBis = inputStream.getClass() == ByteArrayInputStream.class;
       byte[] oldBytes = null;
       if (isBis) {
+        buffer.readerIndex(0);
         oldBytes = buffer.getHeapMemory(); // Note: This should not be null.
         MemoryUtils.wrap((ByteArrayInputStream) inputStream, buffer);
         buffer.increaseReaderIndex(4); // skip size.
@@ -1138,6 +1137,7 @@ public final class Fury {
 
   private static void transferObjectFromStream(InputStream inputStream, MemoryBuffer buffer)
       throws IOException {
+    buffer.readerIndex(0);
     int read = inputStream.read(buffer.getHeapMemory(), 0, 4);
     Preconditions.checkArgument(read == 4);
     int size = buffer.readInt();

--- a/java/fury-core/src/main/java/io/fury/Fury.java
+++ b/java/fury-core/src/main/java/io/fury/Fury.java
@@ -1136,7 +1136,8 @@ public final class Fury {
     }
   }
 
-  private static void transferObjectFromStream(InputStream inputStream, MemoryBuffer buffer) throws IOException {
+  private static void transferObjectFromStream(InputStream inputStream, MemoryBuffer buffer)
+      throws IOException {
     int read = inputStream.read(buffer.getHeapMemory(), 0, 4);
     Preconditions.checkArgument(read == 4);
     int size = buffer.readInt();

--- a/java/fury-core/src/test/java/io/fury/FuryTest.java
+++ b/java/fury-core/src/test/java/io/fury/FuryTest.java
@@ -39,7 +39,6 @@ import io.fury.test.bean.Struct;
 import io.fury.type.Descriptor;
 import io.fury.util.DateTimeUtils;
 import io.fury.util.Platform;
-
 import java.io.*;
 import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
@@ -507,12 +506,13 @@ public class FuryTest extends FuryTestBase {
     fury.serialize(bas, beanA);
     fury.serialize(bas, beanA);
     bas.flush();
-    InputStream bis = new BufferedInputStream(new ByteArrayInputStream(bas.toByteArray())) {
-      @Override
-      public synchronized int read(byte[] b, int off, int len) throws IOException {
-        return in.read(b, off, Math.min(len, 100));
-      }
-    };
+    InputStream bis =
+        new BufferedInputStream(new ByteArrayInputStream(bas.toByteArray())) {
+          @Override
+          public synchronized int read(byte[] b, int off, int len) throws IOException {
+            return in.read(b, off, Math.min(len, 100));
+          }
+        };
     bis.mark(10);
     Object newObj = fury.deserialize(bis);
     assertEquals(newObj, beanA);

--- a/java/fury-core/src/test/java/io/fury/FuryTest.java
+++ b/java/fury-core/src/test/java/io/fury/FuryTest.java
@@ -39,10 +39,8 @@ import io.fury.test.bean.Struct;
 import io.fury.type.Descriptor;
 import io.fury.util.DateTimeUtils;
 import io.fury.util.Platform;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.Serializable;
+
+import java.io.*;
 import java.lang.invoke.MethodHandles;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -487,6 +485,35 @@ public class FuryTest extends FuryTestBase {
     fury.serialize(bas, beanA);
     bas.flush();
     ByteArrayInputStream bis = new ByteArrayInputStream(bas.toByteArray());
+    Object newObj = fury.deserialize(bis);
+    assertEquals(newObj, beanA);
+    newObj = fury.deserialize(bis);
+    assertEquals(newObj, beanA);
+
+    fury = Fury.builder().requireClassRegistration(false).build();
+    // test reader buffer grow
+    bis = new ByteArrayInputStream(bas.toByteArray());
+    newObj = fury.deserialize(bis);
+    assertEquals(newObj, beanA);
+    newObj = fury.deserialize(bis);
+    assertEquals(newObj, beanA);
+  }
+
+  @Test
+  public void testBufferedStream() throws IOException {
+    Fury fury = Fury.builder().requireClassRegistration(false).build();
+    ByteArrayOutputStream bas = new ByteArrayOutputStream();
+    BeanA beanA = BeanA.createBeanA(2);
+    fury.serialize(bas, beanA);
+    fury.serialize(bas, beanA);
+    bas.flush();
+    InputStream bis = new BufferedInputStream(new ByteArrayInputStream(bas.toByteArray())) {
+      @Override
+      public synchronized int read(byte[] b, int off, int len) throws IOException {
+        return in.read(b, off, Math.min(len, 100));
+      }
+    };
+    bis.mark(10);
     Object newObj = fury.deserialize(bis);
     assertEquals(newObj, beanA);
     newObj = fury.deserialize(bis);


### PR DESCRIPTION
The `InputStream#read()` API allows for an implementation to only partially read the requested number of bytes. Update the calls in `Fury#deserialize()` and `Fury#deserializeFromStream()` to account for this.
