### PR TITLE
Update README.md - fix grammatrical errors in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ https://furyio.org
 - **Zero-copy**: cross-language out-of-band serialization inspired
   by [pickle5](https://peps.python.org/pep-0574/) and off-heap read/write.
 - **High performance**: A highly-extensible JIT framework to generate serializer code at runtime in an async multi-thread way to speed serialization, providing 20-170x speed up by:
-    - reduce memory access by inline variable in generated code.
+    - reduce memory access by inline variables in generated code.
     - reduce virtual method invocation by inline call in generated code.
     - reduce conditional branching.
     - reduce hash lookup.
-- **Multiple binary protocols**: object graph, row format and so on.
+- **Multiple binary protocols**: object graph, row format, and so on.
 
 In addition to cross-language serialization, Fury also features at:
 


### PR DESCRIPTION
I have noticed some grammatical mistakes in **README** inside section "**Features**"

"**by inline variable in generated code.**"  should be "**by inline variables in generated code.**"

" **row format and so on.**"  should be " **row format, and so on.**"

Screenshot-

![Screenshot (119)](https://github.com/alipay/fury/assets/115995339/b836189b-ae6b-47cb-99ff-5ac7b64da77d)

