### PR TITLE
[Java] support bytes string serialization for jdk8

### DIFF
--- a/java/fury-benchmark/src/main/java/io/fury/benchmark/NewJava11StringSuite.java
+++ b/java/fury-benchmark/src/main/java/io/fury/benchmark/NewJava11StringSuite.java
@@ -69,7 +69,7 @@ public class NewJava11StringSuite {
 
   // @Benchmark
   public Object createJDK8StringByMethodHandle() {
-    return StringSerializer.newJava11StringByZeroCopy(coder, strBytes);
+    return StringSerializer.newBytesStringZeroCopy(coder, strBytes);
   }
 
   // @Benchmark

--- a/java/fury-benchmark/src/main/java/io/fury/benchmark/NewStringSuite.java
+++ b/java/fury-benchmark/src/main/java/io/fury/benchmark/NewStringSuite.java
@@ -51,7 +51,7 @@ public class NewStringSuite {
 
   // @Benchmark
   public Object createJDK8StringByMethodHandle() {
-    return StringSerializer.newJava8StringByZeroCopy(strData);
+    return StringSerializer.newCharsStringZeroCopy(strData);
   }
 
   // @Benchmark

--- a/java/fury-core/src/main/java/io/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/Serializers.java
@@ -184,9 +184,8 @@ public class Serializers {
               (ToIntFunction<CharSequence>) makeGetterFunction(getCoderMethod, int.class);
           builderCache = Tuple2.of(getCoder, getValue);
         } catch (NoSuchMethodException e) {
-          throw new RuntimeException(e);
+          builderCache = Tuple2.of(null, getValue);
         }
-
       } else {
         builderCache = Tuple2.of(null, getValue);
       }
@@ -220,7 +219,7 @@ public class Serializers {
 
     @Override
     public void write(MemoryBuffer buffer, T value) {
-      if (Platform.JAVA_VERSION > 8) {
+      if (getCoder != null) {
         int coder = getCoder.applyAsInt(value);
         byte[] v = (byte[]) getValue.apply(value);
         buffer.writeByte(coder);

--- a/java/fury-core/src/main/java/io/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/Serializers.java
@@ -236,9 +236,9 @@ public class Serializers {
       } else {
         char[] v = (char[]) getValue.apply(value);
         if (StringSerializer.isLatin(v)) {
-          stringSerializer.writeJDK8Latin(buffer, v, value.length());
+          stringSerializer.writeCharsLatin(buffer, v, value.length());
         } else {
-          stringSerializer.writeJDK8UTF16(buffer, v, value.length());
+          stringSerializer.writeCharsUTF16(buffer, v, value.length());
         }
       }
     }

--- a/java/fury-core/src/main/java/io/fury/serializer/StringSerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/StringSerializer.java
@@ -136,7 +136,7 @@ public final class StringSerializer extends Serializer<String> {
   public Expression writeStringExpr(Expression strSerializer, Expression buffer, Expression str) {
     if (isJava) {
       if (STRING_VALUE_FIELD_IS_BYTES) {
-        return new StaticInvoke(StringSerializer.class, "writeJDK11String", buffer, str);
+        return new StaticInvoke(StringSerializer.class, "writeBytesString", buffer, str);
       } else {
         if (!STRING_VALUE_FIELD_IS_CHARS) {
           throw new UnsupportedOperationException();

--- a/java/fury-core/src/test/java/io/fury/serializer/StringSerializerTest.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/StringSerializerTest.java
@@ -16,7 +16,7 @@
 
 package io.fury.serializer;
 
-import static io.fury.serializer.StringSerializer.newJava11StringByZeroCopy;
+import static io.fury.serializer.StringSerializer.newBytesStringZeroCopy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -83,7 +83,7 @@ public class StringSerializerTest extends FuryTestBase {
       if (STRING_VALUE_FIELD_IS_BYTES) {
         return readJDK11String(buffer);
       } else if (STRING_VALUE_FIELD_IS_CHARS) {
-        return StringSerializer.newJava8StringByZeroCopy(buffer.readCharsWithSizeEmbedded());
+        return StringSerializer.newCharsStringZeroCopy(buffer.readCharsWithSizeEmbedded());
       }
       return null;
     } catch (Exception e) {
@@ -94,7 +94,7 @@ public class StringSerializerTest extends FuryTestBase {
   static String readJDK11String(MemoryBuffer buffer) {
     byte coder = buffer.readByte();
     byte[] value = buffer.readBytesWithSizeEmbedded();
-    return newJava11StringByZeroCopy(coder, value);
+    return newBytesStringZeroCopy(coder, value);
   }
 
   private static boolean writeJavaStringZeroCopy(MemoryBuffer buffer, String value) {
@@ -108,7 +108,7 @@ public class StringSerializerTest extends FuryTestBase {
       valueIsCharsField.setAccessible(true);
       boolean STRING_VALUE_FIELD_IS_CHARS = (Boolean) valueIsCharsField.get(null);
       if (STRING_VALUE_FIELD_IS_BYTES) {
-        StringSerializer.writeJDK11String(buffer, value);
+        StringSerializer.writeBytesString(buffer, value);
       } else if (STRING_VALUE_FIELD_IS_CHARS) {
         writeJDK8String(buffer, value);
       } else {


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This pr supported bytes string serialization for jdk8 by removing all jdk version check in `StringSerializer`
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #1038 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
