### PR TITLE
[Java] Use `ReflectionUtils.getCtrHandle()` in `ExternalizableSerializer`

### DIFF
--- a/java/fury-core/src/main/java/io/fury/serializer/ExternalizableSerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/ExternalizableSerializer.java
@@ -41,6 +41,7 @@ public class ExternalizableSerializer<T extends Externalizable> extends Serializ
     super(fury, cls);
     try {
       constructor = cls.getConstructor();
+      constructor.setAccessible(true);
     } catch (NoSuchMethodException e) {
       Utils.ignore(e);
     }

--- a/java/fury-core/src/main/java/io/fury/serializer/ExternalizableSerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/ExternalizableSerializer.java
@@ -65,7 +65,7 @@ public class ExternalizableSerializer<T extends Externalizable> extends Serializ
     T t;
     if (constructor != null) {
       try {
-        t = (T) constructor.invokeWithArguments();
+        t = (T) constructor.invoke();
       } catch (Throwable e) {
         throw new RuntimeException(e);
       }

--- a/java/fury-core/src/test/java/io/fury/serializer/ExternalizableSerializerTest.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/ExternalizableSerializerTest.java
@@ -27,8 +27,8 @@ import org.testng.annotations.Test;
 public class ExternalizableSerializerTest {
 
   @Test
-  public void testExternalizable() {
-    Externalizable a = Factory.newA(1, 1, "bytes".getBytes());
+  public void testInaccessibleExternalizable() {
+    Externalizable e = Factory.newInstance(1, 1, "bytes".getBytes());
 
     Fury fury =
         Fury.builder()
@@ -36,6 +36,6 @@ public class ExternalizableSerializerTest {
             .withRefTracking(false)
             .requireClassRegistration(false)
             .build();
-    assertEquals(a, fury.deserialize(fury.serialize(a)));
+    assertEquals(e, fury.deserialize(fury.serialize(e)));
   }
 }

--- a/java/fury-core/src/test/java/io/fury/serializer/ExternalizableSerializerTest.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/ExternalizableSerializerTest.java
@@ -18,49 +18,17 @@ package io.fury.serializer;
 
 import static org.testng.Assert.assertEquals;
 
-import com.google.common.base.Preconditions;
 import io.fury.Fury;
 import io.fury.config.Language;
+import io.fury.serializer.test.Factory;
 import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import lombok.Data;
 import org.testng.annotations.Test;
 
 public class ExternalizableSerializerTest {
 
-  @Data
-  public static class A implements Externalizable {
-    private int x;
-    private int y;
-    private byte[] bytes;
-
-    @Override
-    public void writeExternal(ObjectOutput out) throws IOException {
-      out.writeInt(x);
-      out.writeInt(y);
-      out.writeInt(bytes.length);
-      out.write(bytes);
-    }
-
-    @Override
-    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-      this.x = in.readInt();
-      this.y = in.readInt();
-      int len = in.readInt();
-      byte[] arr = new byte[len];
-      Preconditions.checkArgument(in.read(arr) == len);
-      this.bytes = arr;
-    }
-  }
-
   @Test
   public void testExternalizable() {
-    A a = new A();
-    a.x = 1;
-    a.y = 1;
-    a.bytes = "bytes".getBytes();
+    Externalizable a = Factory.newA(1, 1, "bytes".getBytes());
 
     Fury fury =
         Fury.builder()

--- a/java/fury-core/src/test/java/io/fury/serializer/test/A.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/test/A.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.serializer.test;
+
+import com.google.common.base.Preconditions;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import lombok.Data;
+
+@Data
+class A implements Externalizable {
+  private int x;
+  private int y;
+  private byte[] bytes;
+
+  static A create(int x, int y, byte[] bytes) {
+    A a = new A();
+    a.x = x;
+    a.y = y;
+    a.bytes = bytes;
+    return a;
+  }
+
+  @Override
+  public void writeExternal(ObjectOutput out) throws IOException {
+    out.writeInt(x);
+    out.writeInt(y);
+    out.writeInt(bytes.length);
+    out.write(bytes);
+  }
+
+  @Override
+  public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
+    this.x = in.readInt();
+    this.y = in.readInt();
+    int len = in.readInt();
+    byte[] arr = new byte[len];
+    Preconditions.checkArgument(in.read(arr) == len);
+    this.bytes = arr;
+  }
+}

--- a/java/fury-core/src/test/java/io/fury/serializer/test/Factory.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/test/Factory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.serializer.test;
+
+import java.io.Externalizable;
+
+public class Factory {
+  public static Externalizable newA(int x, int y, byte[] bytes) {
+    return A.create(x, y, bytes);
+  }
+}

--- a/java/fury-core/src/test/java/io/fury/serializer/test/Factory.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/test/Factory.java
@@ -18,8 +18,12 @@ package io.fury.serializer.test;
 
 import java.io.Externalizable;
 
+/**
+ * Since {@link Inaccessible} must not be public for the test, we instead provide a public factory
+ * method so that the test can create instances.
+ */
 public class Factory {
-  public static Externalizable newA(int x, int y, byte[] bytes) {
-    return A.create(x, y, bytes);
+  public static Externalizable newInstance(int x, int y, byte[] bytes) {
+    return Inaccessible.create(x, y, bytes);
   }
 }

--- a/java/fury-core/src/test/java/io/fury/serializer/test/Inaccessible.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/test/Inaccessible.java
@@ -23,18 +23,22 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import lombok.Data;
 
+/**
+ * Package-private class for testing {@link io.fury.serializer.ExternalizableSerializer} when the
+ * serialized class is inaccessible to the serializer.
+ */
 @Data
-class A implements Externalizable {
+class Inaccessible implements Externalizable {
   private int x;
   private int y;
   private byte[] bytes;
 
-  static A create(int x, int y, byte[] bytes) {
-    A a = new A();
-    a.x = x;
-    a.y = y;
-    a.bytes = bytes;
-    return a;
+  static Inaccessible create(int x, int y, byte[] bytes) {
+    Inaccessible i = new Inaccessible();
+    i.x = x;
+    i.y = y;
+    i.bytes = bytes;
+    return i;
   }
 
   @Override


### PR DESCRIPTION
When deserializing an `Externalizable` object, it may end up throwing an exception, as the class may be declared as non-public in another package and thus isn't accessible from the serializer. Fix this by using the `ReflectionUtils.getCtrHandle()` utility.