### PR TITLE
[Improve] make maven-spotless-plugin version as a parameter

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -77,6 +77,7 @@
     <jackson-bom.version>2.13.2.20220328</jackson-bom.version>
     <commons_codec.version>1.13</commons_codec.version>
     <fury.java.rootdir>${basedir}</fury.java.rootdir>
+    <maven-spotless-plugin.version>2.5.0</maven-spotless-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -272,7 +273,7 @@
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.5.0</version>
+        <version>${maven-spotless-plugin.version}</version>
         <configuration>
           <java>
             <googleJavaFormat>


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
I find that many open source projects do this, like flink, streampark, etc. I think it is better to set maven-spotless-plugin-version as a parameter

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
