### PR TITLE
[Java] support writeReplace/readResolve for Externalizable

### DIFF
--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -840,8 +840,6 @@ public class ClassResolver {
         return TimeSerializers.ZoneIdSerializer.class;
       } else if (TimeZone.class.isAssignableFrom(cls)) {
         return TimeSerializers.TimeZoneSerializer.class;
-      } else if (Externalizable.class.isAssignableFrom(cls)) {
-        return ExternalizableSerializer.class;
       } else if (ByteBuffer.class.isAssignableFrom(cls)) {
         return BufferSerializers.ByteBufferSerializer.class;
       }
@@ -888,6 +886,9 @@ public class ClassResolver {
       }
       if (useReplaceResolveSerializer(cls)) {
         return ReplaceResolveSerializer.class;
+      }
+      if (Externalizable.class.isAssignableFrom(cls)) {
+        return ExternalizableSerializer.class;
       }
       if (requireJavaSerialization(cls)) {
         return getJavaSerializer(cls);

--- a/java/fury-core/src/main/java/io/fury/serializer/ReplaceResolveSerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/ReplaceResolveSerializer.java
@@ -26,6 +26,7 @@ import io.fury.util.LoggerFactory;
 import io.fury.util.Platform;
 import io.fury.util.ReflectionUtils;
 import io.fury.util.unsafe._JDKAccess;
+import java.io.Externalizable;
 import java.io.ObjectStreamClass;
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
@@ -148,7 +149,9 @@ public class ReplaceResolveSerializer extends Serializer {
     JDKReplaceResolveMethodInfoCache methodInfoCache =
         new JDKReplaceResolveMethodInfoCache(writeReplaceMethod, readResolveMethod, null);
     Class<? extends Serializer> serializerClass;
-    if (JavaSerializer.getReadObjectMethod(cls, true) == null
+    if (Externalizable.class.isAssignableFrom(cls)) {
+      serializerClass = ExternalizableSerializer.class;
+    } else if (JavaSerializer.getReadObjectMethod(cls, true) == null
         && JavaSerializer.getWriteObjectMethod(cls, true) == null) {
       serializerClass =
           fury.getClassResolver()

--- a/java/fury-core/src/test/java/io/fury/FuryTestBase.java
+++ b/java/fury-core/src/test/java/io/fury/FuryTestBase.java
@@ -173,12 +173,12 @@ public abstract class FuryTestBase {
     Assert.assertEquals(serDeCheckSerializer(fury, obj, classRegex), obj);
   }
 
-  public static Object serDeCheckSerializer(Fury fury, Object obj, String classRegex) {
+  public static <T> T serDeCheckSerializer(Fury fury, Object obj, String classRegex) {
     byte[] bytes = fury.serialize(obj);
     String serializerName = fury.getClassResolver().getSerializerClass(obj.getClass()).getName();
     Matcher matcher = Pattern.compile(classRegex).matcher(serializerName);
     Assert.assertTrue(matcher.find());
-    return fury.deserialize(bytes);
+    return (T) fury.deserialize(bytes);
   }
 
   public static Object serDe(Fury fury1, Fury fury2, Object obj) {

--- a/java/fury-core/src/test/java/io/fury/TestUtils.java
+++ b/java/fury-core/src/test/java/io/fury/TestUtils.java
@@ -20,6 +20,9 @@ import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableMap;
 import io.fury.util.FieldAccessor;
 import io.fury.util.ReflectionUtils;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.function.Supplier;
 
@@ -71,6 +74,22 @@ public class TestUtils {
         System.out.println("Met OOM.");
         break;
       }
+    }
+  }
+
+  public static byte[] jdkSerialize(Object data) {
+    ByteArrayOutputStream bas = new ByteArrayOutputStream();
+    jdkSerialize(bas, data);
+    return bas.toByteArray();
+  }
+
+  public static void jdkSerialize(ByteArrayOutputStream bas, Object data) {
+    bas.reset();
+    try (ObjectOutputStream objectOutputStream = new ObjectOutputStream(bas)) {
+      objectOutputStream.writeObject(data);
+      objectOutputStream.flush();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR supports Externalizable which has  a `writeReplace/readResolve` defined by spec: https://docs.oracle.com/javase/8/docs/platform/serialization/spec/output.html. The `writeReplace` can return same type object or different tyoe object, or just return itself.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #1045 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
