### PR TITLE
[Scala] add scala singleton object serializer

### DIFF
--- a/java/fury-core/src/main/java/io/fury/config/Config.java
+++ b/java/fury-core/src/main/java/io/fury/config/Config.java
@@ -52,6 +52,7 @@ public class Config implements Serializable {
   private final boolean shareMetaContext;
   private final boolean asyncCompilationEnabled;
   private final boolean deserializeUnexistedClass;
+  private final boolean scalaOptimizationEnabled;
   private transient int configHash;
 
   public Config(FuryBuilder builder) {
@@ -79,6 +80,7 @@ public class Config implements Serializable {
       Preconditions.checkArgument(shareMetaContext || compatibleMode == CompatibleMode.COMPATIBLE);
     }
     asyncCompilationEnabled = builder.asyncCompilationEnabled;
+    scalaOptimizationEnabled = builder.scalaOptimizationEnabled;
   }
 
   public Language getLanguage() {
@@ -188,6 +190,11 @@ public class Config implements Serializable {
    */
   public boolean isAsyncCompilationEnabled() {
     return asyncCompilationEnabled;
+  }
+
+  /** Whether enable scala-specific serialization optimization. */
+  public boolean isScalaOptimizationEnabled() {
+    return scalaOptimizationEnabled;
   }
 
   public int getConfigHash() {

--- a/java/fury-core/src/main/java/io/fury/config/FuryBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/config/FuryBuilder.java
@@ -69,9 +69,10 @@ public final class FuryBuilder {
   boolean requireClassRegistration = true;
   boolean shareMetaContext = false;
   boolean codeGenEnabled = true;
-  public boolean deserializeUnexistedClass = false;
-  public boolean asyncCompilationEnabled = false;
-  public boolean registerGuavaTypes = true;
+  boolean deserializeUnexistedClass = false;
+  boolean asyncCompilationEnabled = false;
+  boolean registerGuavaTypes = true;
+  boolean scalaOptimizationEnabled = false;
 
   public FuryBuilder() {}
 
@@ -244,6 +245,12 @@ public final class FuryBuilder {
    */
   public FuryBuilder withAsyncCompilation(boolean asyncCompilation) {
     this.asyncCompilationEnabled = asyncCompilation;
+    return this;
+  }
+
+  /** Whether enable scala-specific serialization optimization. */
+  public FuryBuilder withScalaOptimizationEnabled(boolean enableScalaOptimization) {
+    this.scalaOptimizationEnabled = enableScalaOptimization;
     return this;
   }
 

--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -76,6 +76,7 @@ import io.fury.serializer.UnexistedClassSerializers.UnexistedClassSerializer;
 import io.fury.serializer.UnexistedClassSerializers.UnexistedMetaSharedClass;
 import io.fury.serializer.UnexistedClassSerializers.UnexistedSkipClass;
 import io.fury.serializer.UnmodifiableSerializers;
+import io.fury.serializer.scala.SingletonObjectSerializer;
 import io.fury.type.ClassDef;
 import io.fury.type.Descriptor;
 import io.fury.type.GenericType;
@@ -848,6 +849,10 @@ public class ClassResolver {
           throw new UnsupportedOperationException(
               String.format("Class %s doesn't support serialization.", cls));
         }
+      }
+      if (fury.getConfig().isScalaOptimizationEnabled()
+          && ReflectionUtils.isScalaSingletonObject(cls)) {
+        return SingletonObjectSerializer.class;
       }
       if (Collection.class.isAssignableFrom(cls)) {
         // Serializer of common collection such as ArrayList/LinkedList should be registered

--- a/java/fury-core/src/main/java/io/fury/serializer/scala/SingletonObjectSerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/scala/SingletonObjectSerializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.serializer.scala;
+
+import io.fury.Fury;
+import io.fury.memory.MemoryBuffer;
+import io.fury.serializer.Serializer;
+import io.fury.util.Platform;
+import java.lang.reflect.Field;
+
+/**
+ * Serializer for <a href="https://docs.scala-lang.org/tour/singleton-objects.html">scala
+ * singleton</a>.
+ *
+ * @author chaokunyang
+ */
+// TODO(chaokunyang) add scala tests.
+@SuppressWarnings("rawtypes")
+public class SingletonObjectSerializer extends Serializer {
+  private final long offset;
+
+  public SingletonObjectSerializer(Fury fury, Class type) {
+    super(fury, type);
+    try {
+      Field field = type.getDeclaredField("MODULE$");
+      offset = Platform.UNSAFE.staticFieldOffset(field);
+    } catch (NoSuchFieldException e) {
+      throw new RuntimeException(type + " doesn't have `MODULE$` field", e);
+    }
+  }
+
+  @Override
+  public void write(MemoryBuffer buffer, Object value) {}
+
+  @Override
+  public Object read(MemoryBuffer buffer) {
+    return Platform.getObject(type, offset);
+  }
+}

--- a/java/fury-core/src/main/java/io/fury/util/ReflectionUtils.java
+++ b/java/fury-core/src/main/java/io/fury/util/ReflectionUtils.java
@@ -609,4 +609,14 @@ public class ReflectionUtils {
     // TODO(chaokunyang) add cglib check
     return Functions.isLambda(cls) || isJdkProxy(cls);
   }
+
+  /** Returns true if a class is a scala `object` singleton. */
+  public static boolean isScalaSingletonObject(Class<?> cls) {
+    try {
+      cls.getDeclaredField("MODULE$");
+      return true;
+    } catch (NoSuchFieldException e) {
+      return false;
+    }
+  }
 }

--- a/scala/README.md
+++ b/scala/README.md
@@ -1,8 +1,9 @@
 # Fury Scala
 Fury supports all scala object serialization:
-- case class serialization supported
-- object singleton serialization supported
-- collection serialization supported
-- other types such as tuple/either and basic types are all supported too.
+- `case` class serialization supported
+- `pojo/bean` class serialization supported
+- `object` singleton serialization supported
+- `collection` serialization supported
+- other types such as `tuple/either` and basic types are all supported too.
 
 For user document, see [scala_guide](../docs/guide/scala_guide.md).

--- a/scala/src/test/scala/io/fury/serializer/CollectionSerializerTest.scala
+++ b/scala/src/test/scala/io/fury/serializer/CollectionSerializerTest.scala
@@ -25,6 +25,7 @@ class CollectionSerializerTest extends AnyWordSpec with Matchers {
   val fury: Fury = Fury.builder()
     .withLanguage(Language.JAVA)
     .withRefTracking(true)
+    .withScalaOptimizationEnabled(true)
     .requireClassRegistration(false).build()
 
   "fury scala collection support" should {

--- a/scala/src/test/scala/io/fury/serializer/SingleObjectSerializerTest.scala
+++ b/scala/src/test/scala/io/fury/serializer/SingleObjectSerializerTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.serializer
+
+import io.fury.Fury
+import io.fury.config.Language
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+object singleton {}
+
+case class Pair(f1: Any, f2: Any)
+
+class SingleObjectSerializerTest extends AnyWordSpec with Matchers {
+  "fury scala object support" should {
+    "serialize/deserialize" in {
+      val fury = Fury.builder()
+        .withLanguage(Language.JAVA)
+        .withRefTracking(true)
+        .withScalaOptimizationEnabled(true)
+        .requireClassRegistration(false).build()
+      fury.deserialize(fury.serialize(singleton)) shouldBe singleton
+      fury.deserialize(fury.serialize(Pair(singleton, singleton))) shouldEqual Pair(singleton, singleton)
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
This PR optimizes scala `object` serialization be special serializer. To avoid scala check overhead, this PPR introduce a `withScalaOptimization` option which is disabled by default. When this option is enabled, `io.fury.serializer.scala.SingletonObjectSerializer` will be used for `singleton object ` serialization.

The `SingletonObjectSerializer` is put into java source code since the implementation is simple.
Complex scala integration will be put into `fury/scala` directory instead.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #764 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
