### PR TITLE
Empty ListExpression#genCode will throw npe

### DIFF
--- a/java/fury-core/src/main/java/io/fury/codegen/Expression.java
+++ b/java/fury-core/src/main/java/io/fury/codegen/Expression.java
@@ -182,12 +182,16 @@ public interface Expression {
           hasCode = true;
         }
       }
-      ExprCode lastExprCode = last.genCode(ctx);
       String code = codeBuilder.toString();
       if (!hasCode) {
         code = null;
       }
-      return new ExprCode(code, lastExprCode.isNull(), lastExprCode.value());
+      if (code != null) {
+        ExprCode lastExprCode = last.genCode(ctx);
+        return new ExprCode(code, lastExprCode.isNull(), lastExprCode.value());
+      } else {
+        return new ExprCode(code);
+      }
     }
 
     @Override

--- a/java/fury-core/src/main/java/io/fury/codegen/Expression.java
+++ b/java/fury-core/src/main/java/io/fury/codegen/Expression.java
@@ -172,6 +172,10 @@ public interface Expression {
 
     @Override
     public ExprCode doGenCode(CodegenContext ctx) {
+      if (last == null) {
+        return new ExprCode(null, null, null);
+      }
+
       StringBuilder codeBuilder = new StringBuilder();
       boolean hasCode = false;
       for (Expression expr : expressions) {
@@ -182,16 +186,12 @@ public interface Expression {
           hasCode = true;
         }
       }
+      ExprCode lastExprCode = last.genCode(ctx);
       String code = codeBuilder.toString();
       if (!hasCode) {
         code = null;
       }
-      if (code != null) {
-        ExprCode lastExprCode = last.genCode(ctx);
-        return new ExprCode(code, lastExprCode.isNull(), lastExprCode.value());
-      } else {
-        return new ExprCode(code);
-      }
+      return new ExprCode(code, lastExprCode.isNull(), lastExprCode.value());
     }
 
     @Override

--- a/java/fury-core/src/test/java/io/fury/codegen/ExpressionTest.java
+++ b/java/fury-core/src/test/java/io/fury/codegen/ExpressionTest.java
@@ -17,7 +17,9 @@
 package io.fury.codegen;
 
 import static io.fury.type.TypeUtils.PRIMITIVE_SHORT_TYPE;
+import static org.testng.Assert.assertNull;
 
+import io.fury.codegen.Expression.ListExpression;
 import io.fury.codegen.Expression.Literal;
 import io.fury.codegen.Expression.Reference;
 import io.fury.codegen.Expression.Return;
@@ -62,6 +64,15 @@ public class ExpressionTest {
               + "    value = false;\n"
               + "}\n";
       Assert.assertEquals(code, expected);
+    }
+  }
+
+  @Test
+  public void testListExpression() {
+    {
+      ListExpression exp = new ListExpression();
+      String code = exp.genCode(new CodegenContext()).code();
+      assertNull(code);
     }
   }
 }


### PR DESCRIPTION
## What do these changes do?

Empty ListExpression invoke genCode will throw npe. this pull request fix this bug.
