### PR TITLE
[Scala] get build to work with Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: olafurpg/setup-scala@v11
+      - name: Set up JDK8
+        uses: actions/setup-java@v3
+        with:
+          java-version: 8
+          distribution: 'temurin'
       - name: Install fury java
         run: cd java && mvn -T10 clean install -DskipTests && cd -
       - name: Test
-        run: cd scala && sbt test && cd -
+        run: cd scala && sbt +test && cd -
   integration_tests:
     name: integration_tests
     runs-on: ubuntu-latest

--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -1,6 +1,6 @@
 name := "fury-scala"
 scalaVersion := "2.13.12"
-crossScalaVersions := Seq("2.12.18", "2.13.12", "3.3.1")
+crossScalaVersions := Seq("2.13.12", "3.3.1")
 resolvers += Resolver.mavenLocal
 
 val furyVersion = "0.4.0-SNAPSHOT"

--- a/scala/src/main/scala/io/fury/serializer/scala/CollectionSerializer.scala
+++ b/scala/src/main/scala/io/fury/serializer/scala/CollectionSerializer.scala
@@ -87,7 +87,7 @@ private trait JavaIterable[A] extends java.lang.Iterable[A] {
  *
  * @author chaokunyang
  */
-private class CollectionAdapter[A, T](var coll: scala.collection.Iterable[A])
+private class CollectionAdapter[A, T](coll: scala.collection.Iterable[A])
   extends util.AbstractCollection[A] with JavaIterable[A] {
   private var length: Int = -1
 
@@ -99,6 +99,8 @@ private class CollectionAdapter[A, T](var coll: scala.collection.Iterable[A])
   }
 
   override protected def createIterator(): Iterator[A] = coll.iterator
+
+  override def spliterator(): util.Spliterator[A] = super.spliterator()
 }
 
 /**
@@ -106,11 +108,13 @@ private class CollectionAdapter[A, T](var coll: scala.collection.Iterable[A])
  *
  * @author chaokunyang
  */
-private class ListAdapter[A](var coll: scala.collection.Seq[A])
+private class ListAdapter[A](coll: scala.collection.Seq[A])
   extends util.AbstractList[A] with JavaIterable[A] {
   override def get(index: Int): A = coll(index)
 
   override protected def createIterator(): Iterator[A] = coll.iterator
+
+  override def spliterator(): util.Spliterator[A] = super.spliterator()
 
   override def size(): Int = coll.size
 }


### PR DESCRIPTION
* Code needs small hack for spliterator - won't compile in Scala 3 otherwise - possible Scala 3 compiler bug
* removes Scala 2.12 build option beause existing code uses Scala `Factory` class that was only added in Scala 2.13 - if you want to support Scala 2.12, new Scala 2.12 specific code is needed
* updates CI to use `+test` which tests with all the `crossScalaVersions` and gets rid of setup-scala action that is deprecated in favour of setup-java - sbt build tool installs the Scala version it needs anyway so no need to pre-install Scala

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
