### PR TITLE
[Scala] support scala collection jit serialization

### DIFF
--- a/java/fury-core/src/main/java/io/fury/builder/BaseObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/builder/BaseObjectCodecBuilder.java
@@ -281,7 +281,7 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
     ctx.addImports(LazyInitBeanSerializer.class, Serializers.EnumSerializer.class);
     ctx.addImports(Serializer.class, StringSerializer.class);
     ctx.addImports(ObjectSerializer.class, CompatibleSerializer.class);
-    ctx.addImports(AbstractCollectionSerializer.class, AbstractMapSerializer.class, ObjectSerializer.class);
+    ctx.addImports(AbstractCollectionSerializer.class, AbstractMapSerializer.class);
   }
 
   protected Expression serializeFor(
@@ -402,18 +402,16 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
   }
 
   protected boolean useCollectionSerialization(TypeToken<?> typeToken) {
-    return COLLECTION_TYPE.isSupertypeOf(typeToken) || (
-      fury.getConfig().isScalaOptimizationEnabled() && (
-        !ScalaTypes.getScalaMapType().isAssignableFrom(typeToken.getRawType()) &&
-        ScalaTypes.getScalaIterableType().isAssignableFrom(typeToken.getRawType()))
-      );
+    return COLLECTION_TYPE.isSupertypeOf(typeToken)
+        || (fury.getConfig().isScalaOptimizationEnabled()
+            && (!ScalaTypes.getScalaMapType().isAssignableFrom(typeToken.getRawType())
+                && ScalaTypes.getScalaIterableType().isAssignableFrom(typeToken.getRawType())));
   }
 
   protected boolean useMapSerialization(TypeToken<?> typeToken) {
-    return MAP_TYPE.isSupertypeOf(typeToken) || (
-      fury.getConfig().isScalaOptimizationEnabled() &&
-        ScalaTypes.getScalaMapType().isAssignableFrom(typeToken.getRawType())
-    );
+    return MAP_TYPE.isSupertypeOf(typeToken)
+        || (fury.getConfig().isScalaOptimizationEnabled()
+            && ScalaTypes.getScalaMapType().isAssignableFrom(typeToken.getRawType()));
   }
 
   /**
@@ -696,7 +694,8 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
                 false);
       }
     } else if (!TypeToken.of(AbstractCollectionSerializer.class).isSupertypeOf(serializer.type())) {
-      serializer = new Cast(serializer, TypeToken.of(AbstractCollectionSerializer.class), "colSerializer");
+      serializer =
+          new Cast(serializer, TypeToken.of(AbstractCollectionSerializer.class), "colSerializer");
     }
     // write collection data.
     ListExpression actions = new ListExpression();
@@ -1207,7 +1206,10 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
         Expression classInfo = readClassInfo(cls, buffer);
         serializer = new Invoke(classInfo, "getSerializer", "serializer", SERIALIZER_TYPE, false);
         serializer =
-            new Cast(serializer, TypeToken.of(AbstractCollectionSerializer.class), "collectionSerializer");
+            new Cast(
+                serializer,
+                TypeToken.of(AbstractCollectionSerializer.class),
+                "collectionSerializer");
       }
     } else {
       checkArgument(
@@ -1435,7 +1437,8 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
       } else {
         Expression classInfo = readClassInfo(cls, buffer);
         serializer = new Invoke(classInfo, "getSerializer", SERIALIZER_TYPE);
-        serializer = new Cast(serializer, TypeToken.of(AbstractMapSerializer.class), "mapSerializer");
+        serializer =
+            new Cast(serializer, TypeToken.of(AbstractMapSerializer.class), "mapSerializer");
       }
     } else {
       checkArgument(

--- a/java/fury-core/src/main/java/io/fury/type/ScalaTypes.java
+++ b/java/fury-core/src/main/java/io/fury/type/ScalaTypes.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.type;
+
+import com.google.common.reflect.TypeToken;
+import io.fury.collection.Tuple2;
+import io.fury.util.ReflectionUtils;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+/**
+ * Scala types utils using reflection without dependency on scala library.
+ *
+ * @author chaokunyang
+ */
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class ScalaTypes {
+  private static final Class<?> SCALA_MAP_TYPE;
+  private static final Class<?> SCALA_SEQ_TYPE;
+  private static final Class<?> SCALA_ITERABLE_TYPE;
+  private static final Class<?> SCALA_ITERATOR_TYPE;
+  private static final java.lang.reflect.Type SCALA_ITERATOR_RETURN_TYPE;
+  private static final java.lang.reflect.Type SCALA_NEXT_RETURN_TYPE;
+
+  static {
+    try {
+      SCALA_ITERABLE_TYPE = ReflectionUtils.loadClass("scala.collection.Iterable");
+      SCALA_ITERATOR_TYPE = ReflectionUtils.loadClass("scala.collection.Iterator");
+      SCALA_MAP_TYPE = ReflectionUtils.loadClass("scala.collection.Map");
+      SCALA_SEQ_TYPE = ReflectionUtils.loadClass("scala.collection.Seq");
+      SCALA_ITERATOR_RETURN_TYPE = SCALA_ITERABLE_TYPE.getMethod("iterator").getGenericReturnType();
+      SCALA_NEXT_RETURN_TYPE = SCALA_ITERATOR_TYPE.getMethod("next").getGenericReturnType();
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static Class<?> getScalaMapType() {
+    return SCALA_MAP_TYPE;
+  }
+
+  public static Class<?> getScalaSeqType() {
+    return SCALA_SEQ_TYPE;
+  }
+
+  public static Class<?> getScalaIterableType() {
+    return SCALA_ITERABLE_TYPE;
+  }
+
+  public static TypeToken<?> getElementType(TypeToken typeToken) {
+    TypeToken<?> supertype = typeToken.getSupertype(getScalaIterableType());
+    return supertype.resolveType(SCALA_ITERATOR_RETURN_TYPE)
+      .resolveType(SCALA_NEXT_RETURN_TYPE);
+  }
+
+  /** Returns key/value type of scala map. */
+  public static Tuple2<TypeToken<?>, TypeToken<?>> getMapKeyValueType(TypeToken typeToken) {
+    TypeToken<?> kvTupleType = getElementType(typeToken);
+    ParameterizedType type = (ParameterizedType) kvTupleType.getType();
+    Type[] types = type.getActualTypeArguments();
+    return Tuple2.of(TypeToken.of(types[0]), TypeToken.of(types[1]));
+  }
+}

--- a/java/fury-core/src/main/java/io/fury/type/ScalaTypes.java
+++ b/java/fury-core/src/main/java/io/fury/type/ScalaTypes.java
@@ -19,7 +19,6 @@ package io.fury.type;
 import com.google.common.reflect.TypeToken;
 import io.fury.collection.Tuple2;
 import io.fury.util.ReflectionUtils;
-
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 
@@ -64,8 +63,7 @@ public class ScalaTypes {
 
   public static TypeToken<?> getElementType(TypeToken typeToken) {
     TypeToken<?> supertype = typeToken.getSupertype(getScalaIterableType());
-    return supertype.resolveType(SCALA_ITERATOR_RETURN_TYPE)
-      .resolveType(SCALA_NEXT_RETURN_TYPE);
+    return supertype.resolveType(SCALA_ITERATOR_RETURN_TYPE).resolveType(SCALA_NEXT_RETURN_TYPE);
   }
 
   /** Returns key/value type of scala map. */

--- a/java/fury-core/src/main/java/io/fury/type/TypeUtils.java
+++ b/java/fury-core/src/main/java/io/fury/type/TypeUtils.java
@@ -55,7 +55,7 @@ import java.util.stream.Collectors;
  *
  * @author chaokunyang
  */
-@SuppressWarnings("UnstableApiUsage")
+@SuppressWarnings({"UnstableApiUsage", "unchecked"})
 public class TypeUtils {
   public static final String JAVA_BOOLEAN = "boolean";
   public static final String JAVA_BYTE = "byte";
@@ -419,7 +419,9 @@ public class TypeUtils {
         }
       }
     }
-    @SuppressWarnings("unchecked")
+    if (typeToken.getType().getTypeName().startsWith("scala.collection")) {
+     return ScalaTypes.getElementType(typeToken);
+    }
     TypeToken<?> supertype =
         ((TypeToken<? extends Iterable<?>>) typeToken).getSupertype(Iterable.class);
     return supertype.resolveType(ITERATOR_RETURN_TYPE).resolveType(NEXT_RETURN_TYPE);
@@ -447,6 +449,9 @@ public class TypeUtils {
               TypeToken.of(actualTypeArguments[0]), TypeToken.of(actualTypeArguments[1]));
         }
       }
+    }
+    if (typeToken.getType().getTypeName().startsWith("scala.collection")) {
+      return ScalaTypes.getMapKeyValueType(typeToken);
     }
     @SuppressWarnings("unchecked")
     TypeToken<?> supertype = ((TypeToken<? extends Map<?, ?>>) typeToken).getSupertype(Map.class);
@@ -690,30 +695,5 @@ public class TypeUtils {
     }
 
     return new ArrayList<>(allTypeArguments);
-  }
-
-  private static volatile TypeToken<?> scalaMapType;
-  private static volatile TypeToken<?> scalaSeqType;
-  private static volatile TypeToken<?> scalaIterableType;
-
-  public static TypeToken<?> getScalaMapType() {
-    if (scalaMapType == null) {
-      scalaMapType = TypeToken.of(ReflectionUtils.loadClass("scala.collection.Map"));
-    }
-    return scalaMapType;
-  }
-
-  public static TypeToken<?> getScalaSeqType() {
-    if (scalaSeqType == null) {
-      scalaSeqType = TypeToken.of(ReflectionUtils.loadClass("scala.collection.Seq"));
-    }
-    return scalaSeqType;
-  }
-
-  public static TypeToken<?> getScalaIterableType() {
-    if (scalaIterableType == null) {
-      scalaIterableType = TypeToken.of(ReflectionUtils.loadClass("scala.collection.Iterable"));
-    }
-    return scalaIterableType;
   }
 }

--- a/java/fury-core/src/main/java/io/fury/type/TypeUtils.java
+++ b/java/fury-core/src/main/java/io/fury/type/TypeUtils.java
@@ -420,7 +420,7 @@ public class TypeUtils {
       }
     }
     if (typeToken.getType().getTypeName().startsWith("scala.collection")) {
-     return ScalaTypes.getElementType(typeToken);
+      return ScalaTypes.getElementType(typeToken);
     }
     TypeToken<?> supertype =
         ((TypeToken<? extends Iterable<?>>) typeToken).getSupertype(Iterable.class);

--- a/scala/src/main/java/io/fury/serializer/scala/ScalaDispatcher.java
+++ b/scala/src/main/java/io/fury/serializer/scala/ScalaDispatcher.java
@@ -41,20 +41,20 @@ public class ScalaDispatcher implements SerializerFactory {
    */
   @Override
   public Serializer createSerializer(Fury fury, Class<?> clz) {
+    // Many map/seq/set types doesn't extends DefaultSerializable.
+    if (scala.collection.SortedMap.class.isAssignableFrom(clz)) {
+      return new ScalaSortedMapSerializer(fury, clz);
+    } else if (scala.collection.Map.class.isAssignableFrom(clz)) {
+      return new ScalaMapSerializer(fury, clz);
+    } else if (scala.collection.SortedSet.class.isAssignableFrom(clz)) {
+      return new ScalaSortedSetSerializer(fury, clz);
+    } else if (scala.collection.Seq.class.isAssignableFrom(clz)) {
+      return new ScalaSeqSerializer(fury, clz);
+    }
     if (DefaultSerializable.class.isAssignableFrom(clz)) {
       Method replaceMethod = JavaSerializer.getWriteReplaceMethod(clz);
       Preconditions.checkNotNull(replaceMethod);
-      if (scala.collection.SortedMap.class.isAssignableFrom(clz)) {
-        return new ScalaSortedMapSerializer(fury, clz);
-      } else if (scala.collection.Map.class.isAssignableFrom(clz)) {
-        return new ScalaMapSerializer(fury, clz);
-      } else if (scala.collection.SortedSet.class.isAssignableFrom(clz)) {
-        return new ScalaSortedSetSerializer(fury, clz);
-      } else if (scala.collection.Seq.class.isAssignableFrom(clz)) {
-        return new ScalaSeqSerializer(fury, clz);
-      } else {
-        return new ScalaCollectionSerializer(fury, clz);
-      }
+      return new ScalaCollectionSerializer(fury, clz);
     }
     return null;
   }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
-  Support scala collection jit serialization
- Relax `ScalaDispatcher` to intercept all scala map/seq/set types.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #1076 

#765 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
