### PR TITLE
[Java] when user disable class registration, turn off frequent and annoying log warnings

### DIFF
--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -1149,7 +1149,7 @@ public class ClassResolver {
       if (forbidden || !isSecure(extRegistry.registeredClassIdMap, cls)) {
         throw new InsecureException(msg);
       } else {
-        if (!Functions.isLambda(cls) && !ReflectionUtils.isJdkProxy(cls)) {
+        if (!fury.getConfig().requireClassRegistration() && !Functions.isLambda(cls) && !ReflectionUtils.isJdkProxy(cls)) {
           LOG.warn(msg);
         }
       }


### PR DESCRIPTION
## What do these changes do?

when user decides to disable class register, we have enough log to show risk, this PR turn off frequent and annoying log warnings in high concurrency environment。

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

none

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
