### PR TITLE
[Java] When user disable class registration, turn off frequent and annoying log warnings

### DIFF
--- a/java/fury-core/src/main/java/io/fury/config/Config.java
+++ b/java/fury-core/src/main/java/io/fury/config/Config.java
@@ -48,6 +48,7 @@ public class Config implements Serializable {
   private final boolean compressLong;
   private final LongEncoding longEncoding;
   private final boolean requireClassRegistration;
+  private final boolean classRegistrationWarningIgnored;
   private final boolean registerGuavaTypes;
   private final boolean shareMetaContext;
   private final boolean asyncCompilationEnabled;
@@ -66,6 +67,7 @@ public class Config implements Serializable {
     longEncoding = builder.longEncoding;
     compressLong = longEncoding != LongEncoding.LE_RAW_BYTES;
     requireClassRegistration = builder.requireClassRegistration;
+    classRegistrationWarningIgnored = builder.classRegistrationWarningIgnored;
     registerGuavaTypes = builder.registerGuavaTypes;
     codeGenEnabled = builder.codeGenEnabled;
     checkClassVersion = builder.checkClassVersion;
@@ -148,6 +150,10 @@ public class Config implements Serializable {
 
   public boolean requireClassRegistration() {
     return requireClassRegistration;
+  }
+
+  public boolean classRegistrationWarningIgnored() {
+    return classRegistrationWarningIgnored;
   }
 
   public boolean registerGuavaTypes() {

--- a/java/fury-core/src/main/java/io/fury/config/FuryBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/config/FuryBuilder.java
@@ -213,7 +213,7 @@ public final class FuryBuilder {
     return this;
   }
 
-  /** Only takes effect when using `FuryBuilder#requireClassRegistration(false)` */
+  /** Only takes effect when using `FuryBuilder#requireClassRegistration(false)`. */
   public FuryBuilder classRegistrationWarningIgnored(boolean classRegistrationWarningIgnored) {
     this.classRegistrationWarningIgnored = classRegistrationWarningIgnored;
     return this;

--- a/java/fury-core/src/main/java/io/fury/config/FuryBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/config/FuryBuilder.java
@@ -213,9 +213,7 @@ public final class FuryBuilder {
     return this;
   }
 
-  /**
-   * Only takes effect when using `FuryBuilder#requireClassRegistration(false)`
-   */
+  /** Only takes effect when using `FuryBuilder#requireClassRegistration(false)` */
   public FuryBuilder classRegistrationWarningIgnored(boolean classRegistrationWarningIgnored) {
     this.classRegistrationWarningIgnored = classRegistrationWarningIgnored;
     return this;

--- a/java/fury-core/src/main/java/io/fury/config/FuryBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/config/FuryBuilder.java
@@ -68,6 +68,7 @@ public final class FuryBuilder {
   boolean checkJdkClassSerializable = true;
   Class<? extends Serializer> defaultJDKStreamSerializerType = ObjectStreamSerializer.class;
   boolean requireClassRegistration = true;
+  boolean classRegistrationWarningIgnored = false;
   boolean shareMetaContext = false;
   boolean codeGenEnabled = true;
   boolean deserializeUnexistedClass = false;
@@ -209,6 +210,14 @@ public final class FuryBuilder {
    */
   public FuryBuilder requireClassRegistration(boolean requireClassRegistration) {
     this.requireClassRegistration = requireClassRegistration;
+    return this;
+  }
+
+  /**
+   * Only takes effect when using `FuryBuilder#requireClassRegistration(false)`
+   */
+  public FuryBuilder classRegistrationWarningIgnored(boolean classRegistrationWarningIgnored) {
+    this.classRegistrationWarningIgnored = classRegistrationWarningIgnored;
     return this;
   }
 

--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -1148,7 +1148,7 @@ public class ClassResolver {
       boolean forbidden = BlackList.getDefaultBlackList().contains(cls.getName());
       if (forbidden || !isSecure(extRegistry.registeredClassIdMap, cls)) {
         throw new InsecureException(msg);
-      } else {
+      } else if(fury.getConfig().requireClassRegistration()) {
         if (!Functions.isLambda(cls) && !ReflectionUtils.isJdkProxy(cls)) {
           LOG.warn(msg);
         }

--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -1148,7 +1148,7 @@ public class ClassResolver {
       boolean forbidden = BlackList.getDefaultBlackList().contains(cls.getName());
       if (forbidden || !isSecure(extRegistry.registeredClassIdMap, cls)) {
         throw new InsecureException(msg);
-      } else if(fury.getConfig().requireClassRegistration()) {
+      } else if (fury.getConfig().requireClassRegistration()) {
         if (!Functions.isLambda(cls) && !ReflectionUtils.isJdkProxy(cls)) {
           LOG.warn(msg);
         }

--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -1148,7 +1148,7 @@ public class ClassResolver {
       boolean forbidden = BlackList.getDefaultBlackList().contains(cls.getName());
       if (forbidden || !isSecure(extRegistry.registeredClassIdMap, cls)) {
         throw new InsecureException(msg);
-      } else if (fury.getConfig().requireClassRegistration()) {
+      } else if (!fury.getConfig().classRegistrationWarningIgnored()) {
         if (!Functions.isLambda(cls) && !ReflectionUtils.isJdkProxy(cls)) {
           LOG.warn(msg);
         }


### PR DESCRIPTION
## What do these changes do?

When user decides to disable class register, we have enough log to show risk, this PR turn off frequent and annoying log warnings in high concurrency environment.

## Related issue number

none

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
