### PR TITLE
[Java] Fix collection serialization NPE when all elements are null

### DIFF
--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -21,6 +21,7 @@ import static io.fury.codegen.ExpressionUtils.eq;
 import static io.fury.serializer.CodegenSerializer.loadCodegenSerializer;
 import static io.fury.serializer.CodegenSerializer.loadCompatibleCodegenSerializer;
 import static io.fury.serializer.CodegenSerializer.supportCodegenForJavaSerialization;
+import static io.fury.type.TypeUtils.OBJECT_TYPE;
 import static io.fury.type.TypeUtils.PRIMITIVE_SHORT_TYPE;
 import static io.fury.type.TypeUtils.getRawType;
 
@@ -263,6 +264,7 @@ public class ClassResolver {
     private final ConcurrentHashMap<Tuple2<Class<?>, Boolean>, SortedMap<Field, Descriptor>>
         descriptorsCache = new ConcurrentHashMap<>();
     private ClassChecker classChecker = (classResolver, className) -> true;
+    private GenericType objectGenericType;
   }
 
   public ClassResolver(Fury fury) {
@@ -271,6 +273,7 @@ public class ClassResolver {
     classInfoCache = NIL_CLASS_INFO;
     metaContextShareEnabled = fury.getConfig().shareMetaContext();
     extRegistry = new ExtRegistry();
+    extRegistry.objectGenericType = buildGenericType(OBJECT_TYPE);
   }
 
   public void initialize() {
@@ -1749,6 +1752,10 @@ public class ClassResolver {
             return isFinal(getRawType(t));
           }
         });
+  }
+
+  public GenericType getObjectGenericType() {
+    return extRegistry.objectGenericType;
   }
 
   public ClassInfo newClassInfo(Class<?> cls, Serializer<?> serializer, short classId) {

--- a/java/fury-core/src/main/java/io/fury/serializer/collection/AbstractCollectionSerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/collection/AbstractCollectionSerializer.java
@@ -16,7 +16,6 @@
 
 package io.fury.serializer.collection;
 
-import com.google.common.base.Preconditions;
 import io.fury.Fury;
 import io.fury.annotation.CodegenInvoke;
 import io.fury.memory.MemoryBuffer;
@@ -260,6 +259,7 @@ public abstract class AbstractCollectionSerializer<T> extends Serializer<T> {
       bitmap |= Flags.HAS_NULL;
     }
     if (hasDifferentClass) {
+      // If collection contains null only, the type header will be meaningless
       bitmap |= Flags.NOT_SAME_TYPE | Flags.NOT_DECL_ELEMENT_TYPE;
       buffer.writeByte(bitmap);
     } else {
@@ -362,6 +362,11 @@ public abstract class AbstractCollectionSerializer<T> extends Serializer<T> {
     if ((flags & Flags.NOT_SAME_TYPE) != Flags.NOT_SAME_TYPE) {
       Serializer serializer;
       if ((flags & Flags.NOT_DECL_ELEMENT_TYPE) != Flags.NOT_DECL_ELEMENT_TYPE) {
+        // When serialize a collection with all elements null directly, the declare type
+        // will be equal to element type: null
+        if (elemGenericType == null) {
+          elemGenericType = fury.getClassResolver().getObjectGenericType();
+        }
         serializer = elemGenericType.getSerializer(fury.getClassResolver());
       } else {
         serializer = elementClassInfoHolder.getSerializer();
@@ -585,7 +590,11 @@ public abstract class AbstractCollectionSerializer<T> extends Serializer<T> {
       if ((flags & Flags.NOT_DECL_ELEMENT_TYPE) == Flags.NOT_DECL_ELEMENT_TYPE) {
         serializer = classResolver.readClassInfo(buffer, elementClassInfoHolder).getSerializer();
       } else {
-        Preconditions.checkNotNull(elemGenericType);
+        // When serialize a collection with all elements null directly, the declare type
+        // will be equal to element type: null
+        if (elemGenericType == null) {
+          elemGenericType = fury.getClassResolver().getObjectGenericType();
+        }
         serializer = elemGenericType.getSerializer(classResolver);
       }
       readSameTypeElements(fury, buffer, serializer, flags, collection, numElements);

--- a/java/fury-core/src/test/java/io/fury/serializer/collection/CollectionSerializersTest.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/collection/CollectionSerializersTest.java
@@ -515,4 +515,14 @@ public class CollectionSerializersTest extends FuryTestBase {
     //     Object o = deserialize(new Hessian2Input(new ByteArrayInputStream(bas.toByteArray())));
     //     System.out.println(o.getClass());
   }
+
+  @Test
+  public void testCollectionNullElements() {
+    // When serialize a collection with all elements null directly, the declare type
+    // will be equal to element type: null
+    List data = new ArrayList<>();
+    data.add(null);
+    Fury f = Fury.builder().withLanguage(Language.JAVA).build();
+    serDeCheck(f, data);
+  }
 }

--- a/java/fury-core/src/test/java/io/fury/serializer/collection/CollectionSerializersTest.java
+++ b/java/fury-core/src/test/java/io/fury/serializer/collection/CollectionSerializersTest.java
@@ -93,6 +93,7 @@ public class CollectionSerializersTest extends FuryTestBase {
     fury.getGenerics().pushGenericType(GenericType.build(new TypeToken<List<String>>() {}));
     byte[] bytes2 = fury.serialize(data);
     Assert.assertTrue(bytes1.length > bytes2.length);
+    assertEquals(fury.deserialize(bytes2), data);
     fury.getGenerics().popGenericType();
     Assert.assertThrows(RuntimeException.class, () -> fury.deserialize(bytes2));
   }
@@ -516,13 +517,13 @@ public class CollectionSerializersTest extends FuryTestBase {
     //     System.out.println(o.getClass());
   }
 
-  @Test
-  public void testCollectionNullElements() {
+  @Test(dataProvider = "referenceTrackingConfig")
+  public void testCollectionNullElements(boolean refTracking) {
     // When serialize a collection with all elements null directly, the declare type
     // will be equal to element type: null
     List data = new ArrayList<>();
     data.add(null);
-    Fury f = Fury.builder().withLanguage(Language.JAVA).build();
+    Fury f = Fury.builder().withLanguage(Language.JAVA).withRefTracking(refTracking).build();
     serDeCheck(f, data);
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

When all elements are null, actual collection  element type will be null. If there is no collection generics, the declared collection element type will be null too, then serialization for such collection will throw NullPointerException:
![image](https://github.com/alipay/fury/assets/12445254/43c7d94a-0048-4071-ace5-5c78032ace65)

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #1085 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
