### PR TITLE
[Java] FuryPooledObjectFactory getFury refactor, remove redundant recursive call

### DIFF
--- a/java/fury-core/src/main/java/io/fury/pool/FuryPooledObjectFactory.java
+++ b/java/fury-core/src/main/java/io/fury/pool/FuryPooledObjectFactory.java
@@ -84,7 +84,7 @@ public class FuryPooledObjectFactory {
       ClassLoaderFuryPooled classLoaderFuryPooled =
           classLoaderFuryPooledCache.getIfPresent(classLoader);
       if (classLoaderFuryPooled == null) {
-       // double check cache
+        // double check cache
         ClassLoaderFuryPooled cache = getOrAddCache(classLoader);
         return cache.getFury();
       }

--- a/java/fury-core/src/main/java/io/fury/pool/FuryPooledObjectFactory.java
+++ b/java/fury-core/src/main/java/io/fury/pool/FuryPooledObjectFactory.java
@@ -84,9 +84,9 @@ public class FuryPooledObjectFactory {
       ClassLoaderFuryPooled classLoaderFuryPooled =
           classLoaderFuryPooledCache.getIfPresent(classLoader);
       if (classLoaderFuryPooled == null) {
-        // ifPresent will be cleared when cache expire 30's
-        addCache(classLoader);
-        return getFury();
+       // double check cache
+        ClassLoaderFuryPooled cache = getOrAddCache(classLoader);
+        return cache.getFury();
       }
       return classLoaderFuryPooled.getFury();
     } catch (Exception e) {
@@ -114,7 +114,7 @@ public class FuryPooledObjectFactory {
   /** todo setClassLoader support LoaderBinding.StagingType */
   public void setClassLoader(ClassLoader classLoader, LoaderBinding.StagingType stagingType) {
     classLoaderLocal.set(classLoader);
-    addCache(classLoader);
+    getOrAddCache(classLoader);
   }
 
   public ClassLoader getClassLoader() {
@@ -126,7 +126,8 @@ public class FuryPooledObjectFactory {
     classLoaderLocal.remove();
   }
 
-  private synchronized void addCache(ClassLoader classLoader) {
+  /** get cache or put newly added pooledFury */
+  private synchronized ClassLoaderFuryPooled getOrAddCache(ClassLoader classLoader) {
     ClassLoaderFuryPooled classLoaderFuryPooled =
         classLoaderFuryPooledCache.getIfPresent(classLoader);
     if (classLoaderFuryPooled == null) {
@@ -134,5 +135,6 @@ public class FuryPooledObjectFactory {
           new ClassLoaderFuryPooled(classLoader, furyFactory, minPoolSize, maxPoolSize);
       classLoaderFuryPooledCache.put(classLoader, classLoaderFuryPooled);
     }
+    return classLoaderFuryPooled;
   }
 }

--- a/java/fury-core/src/main/java/io/fury/pool/FuryPooledObjectFactory.java
+++ b/java/fury-core/src/main/java/io/fury/pool/FuryPooledObjectFactory.java
@@ -126,7 +126,7 @@ public class FuryPooledObjectFactory {
     classLoaderLocal.remove();
   }
 
-  /** get cache or put newly added pooledFury */
+  /** Get cache or put new added pooledFury. */
   private synchronized ClassLoaderFuryPooled getOrAddCache(ClassLoader classLoader) {
     ClassLoaderFuryPooled classLoaderFuryPooled =
         classLoaderFuryPooledCache.getIfPresent(classLoader);


### PR DESCRIPTION
## What do these changes do?
Before this refactor, when pooled fury cache not present:
1. double check cache present
2. put in cache
3. recursive call get function

In order to avoid recursive call, we could return cached obj or newly added cache object
thus rename addCache to getOrAddCache