### PR TITLE
Fix undefined behavior due to use of uninitialized field in Buffer

### DIFF
--- a/src/fury/util/buffer.cc
+++ b/src/fury/util/buffer.cc
@@ -30,10 +30,6 @@ Buffer::Buffer() {
 }
 
 Buffer::Buffer(Buffer &&buffer) noexcept {
-  if (own_data_) {
-    delete data_;
-    data_ = nullptr;
-  }
   data_ = buffer.data_;
   size_ = buffer.size_;
   own_data_ = buffer.own_data_;


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

There are two point about this change:
- In the constructor `Buffer::Buffer`, `own_data_` is used but not initialized which is an undefined behavior, so that it may contain arbitrary value rather than `false`.
- It is no necessary to check `own_data_` since it is a constructor and the buffer is always constructed without owning any `data_`.
