### PR TITLE
Simplify endian utility functions and `IsOneOf`

### DIFF
--- a/src/fury/util/util.h
+++ b/src/fury/util/util.h
@@ -174,13 +174,11 @@ static inline T ToLittleEndian(T value) {
 }
 
 // Convert from big/little endian format to the machine's native endian format.
-template <typename T>
-static inline T FromBigEndian(T value) {
+template <typename T> static inline T FromBigEndian(T value) {
   return ToBigEndian(value);
 }
 
-template <typename T>
-static inline T FromLittleEndian(T value) {
+template <typename T> static inline T FromLittleEndian(T value) {
   return ToLittleEndian(value);
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

- Simplify the implementation of `IsOneOf`
- Simplify the implementation of `To/FromBig/LittleEndian` via `if constexpr`

BTW I think maybe there's no difference between `ToXXXEndian` and `FromXXXEndian`.
