### PR TITLE
chore: check xlang flag

### DIFF
--- a/rust/fury/src/error.rs
+++ b/rust/fury/src/error.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::FieldType;
+use crate::{FieldType, Language};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -42,4 +42,10 @@ pub enum Error {
 
     #[error("Bad Tag Type: {0}")]
     TagType(u8),
+
+    #[error("Only Xlang supported; receive: {language:?}")]
+    UnsupportLanguage { language: Language },
+
+    #[error("Unsupported Language Code; receive: {code:?}")]
+    UnsupportLanguageCode { code: u8 },
 }

--- a/rust/fury/src/types.rs
+++ b/rust/fury/src/types.rs
@@ -19,6 +19,8 @@ use std::{
 
 use chrono::{NaiveDate, NaiveDateTime};
 
+use crate::Error;
+
 pub trait FuryMeta {
     fn ty() -> FieldType;
 
@@ -235,6 +237,7 @@ pub mod config_flags {
     pub const IS_OUT_OF_BAND_FLAG: u8 = 8;
 }
 
+#[derive(Debug)]
 pub enum Language {
     XLANG = 0,
     JAVA = 1,
@@ -243,6 +246,23 @@ pub enum Language {
     GO = 4,
     JAVASCRIPT = 5,
     RUST = 6,
+}
+
+impl TryFrom<u8> for Language {
+    type Error = Error;
+
+    fn try_from(num: u8) -> Result<Self, Error> {
+        match num {
+            0 => Ok(Language::XLANG),
+            1 => Ok(Language::JAVA),
+            2 => Ok(Language::PYTHON),
+            3 => Ok(Language::CPP),
+            4 => Ok(Language::GO),
+            5 => Ok(Language::JAVASCRIPT),
+            6 => Ok(Language::RUST),
+            _ => Err(Error::UnsupportLanguageCode { code: num }),
+        }
+    }
 }
 
 // every object start with i8 i16 reference flag and type flag


### PR DESCRIPTION


## What do these changes do?
Check xlang flag, currently Rust only supports xlang. If the flag is unsupported, we should generate a friendly error.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #1111 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
