### PR TITLE
[Rust] Correct language flag

### DIFF
--- a/rust/fury/src/serializer.rs
+++ b/rust/fury/src/serializer.rs
@@ -344,7 +344,7 @@ impl<'de> SerializerState<'de> {
         bitmap |= config_flags::IS_LITTLE_ENDIAN_FLAG;
         bitmap |= config_flags::IS_CROSS_LANGUAGE_FLAG;
         self.writer.u8(bitmap);
-        self.writer.u8(Language::RUST as u8);
+        self.writer.u8(Language::XLANG as u8);
         self.writer.skip(4); // native offset
         self.writer.skip(4); // native size
         self


### PR DESCRIPTION

## What do these changes do?
Rust does not yet support native data, so we should set the language flag as Xlang.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #1119 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
