### PR TITLE
[Java] DateTimeUtils minor refactor, reuse floorDiv to calculate floo…

### DIFF
--- a/java/fury-core/src/main/java/io/fury/util/DateTimeUtils.java
+++ b/java/fury-core/src/main/java/io/fury/util/DateTimeUtils.java
@@ -117,7 +117,7 @@ public class DateTimeUtils {
 
   public static Instant microsToInstant(long us) {
     long secs = Math.floorDiv(us, MICROS_PER_SECOND);
-    long mos = Math.floorMod(us, MICROS_PER_SECOND);
+    long mos = MathUtils.floorMod(us, MICROS_PER_SECOND, secs);
     return Instant.ofEpochSecond(secs, mos * NANOS_PER_MICROS);
   }
 

--- a/java/fury-core/src/main/java/io/fury/util/MathUtils.java
+++ b/java/fury-core/src/main/java/io/fury/util/MathUtils.java
@@ -30,4 +30,17 @@ public class MathUtils {
     }
     return (int) r;
   }
+
+    /**
+     * Reuse floorDiv to calculate floorMod.
+     * @see Math#floorMod(long, long)
+     * @param x the dividend
+     * @param y the divisor
+     * @param floorDiv of java.lang.Math#floorDiv(x, y)
+     * @return the floor modulus {@code x - (floorDiv(x, y) * y)}
+     * @since 1.8
+     */
+    public static long floorMod(long x, long y, long floorDiv) {
+        return x - floorDiv * y;
+    }
 }


### PR DESCRIPTION
## What do these changes do?
we can reuse Math.floorDiv result to calculate floorMod according to the code implement from Math.floorMod

action: add util function in MathUtils