### PR TITLE
[C++] Remove useless overload of Writer::WriteString

### DIFF
--- a/src/fury/row/writer.cc
+++ b/src/fury/row/writer.cc
@@ -48,12 +48,7 @@ bool Writer::IsNullAt(int i) const {
                          static_cast<uint32_t>(i));
 }
 
-void Writer::WriteString(int i, std::string &value) {
-  WriteBytes(i, reinterpret_cast<const uint8_t *>(value.data()),
-             static_cast<int32_t>(value.size()));
-}
-
-void Writer::WriteString(int i, std::string &&value) {
+void Writer::WriteString(int i, const std::string &value) {
   WriteBytes(i, reinterpret_cast<const uint8_t *>(value.data()),
              static_cast<int32_t>(value.size()));
 }

--- a/src/fury/row/writer.h
+++ b/src/fury/row/writer.h
@@ -92,9 +92,7 @@ public:
     buffer_->UnsafePut(GetOffset(i), value);
   }
 
-  void WriteString(int i, std::string &value);
-
-  void WriteString(int i, std::string &&value);
+  void WriteString(int i, const std::string &value);
 
   void WriteBytes(int i, const uint8_t *input, uint32_t length);
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- Make Writer::WriteString accept const reference
- Remove the rvalue reference one since it's same