### PR TITLE
[Scala] Fix scala collection serialization nested in pojo

### DIFF
--- a/java/fury-core/src/main/java/io/fury/builder/BaseObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/builder/BaseObjectCodecBuilder.java
@@ -80,7 +80,6 @@ import io.fury.serializer.Serializers;
 import io.fury.serializer.StringSerializer;
 import io.fury.serializer.collection.AbstractCollectionSerializer;
 import io.fury.serializer.collection.AbstractMapSerializer;
-import io.fury.type.ScalaTypes;
 import io.fury.type.TypeUtils;
 import io.fury.util.Preconditions;
 import io.fury.util.ReflectionUtils;
@@ -402,16 +401,11 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
   }
 
   protected boolean useCollectionSerialization(TypeToken<?> typeToken) {
-    return COLLECTION_TYPE.isSupertypeOf(typeToken)
-        || (fury.getConfig().isScalaOptimizationEnabled()
-            && (!ScalaTypes.getScalaMapType().isAssignableFrom(typeToken.getRawType())
-                && ScalaTypes.getScalaIterableType().isAssignableFrom(typeToken.getRawType())));
+    return visitFury(f -> f.getClassResolver().isCollection(TypeUtils.getRawType(typeToken)));
   }
 
   protected boolean useMapSerialization(TypeToken<?> typeToken) {
-    return MAP_TYPE.isSupertypeOf(typeToken)
-        || (fury.getConfig().isScalaOptimizationEnabled()
-            && ScalaTypes.getScalaMapType().isAssignableFrom(typeToken.getRawType()));
+    return visitFury(f -> f.getClassResolver().isMap(TypeUtils.getRawType(typeToken)));
   }
 
   /**

--- a/java/fury-core/src/main/java/io/fury/serializer/collection/CollectionSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/collection/CollectionSerializers.java
@@ -498,8 +498,8 @@ public class CollectionSerializers {
    * serializer won't use element generics and doesn't support JIT, performance won't be the best,
    * but the correctness can be ensured.
    */
-  public static final class DefaultJavaCollectionSerializer<T extends Collection>
-      extends CollectionSerializer<T> {
+  public static final class DefaultJavaCollectionSerializer<T>
+      extends AbstractCollectionSerializer<T> {
     private Serializer<T> dataSerializer;
 
     public DefaultJavaCollectionSerializer(Fury fury, Class<T> cls) {
@@ -518,6 +518,16 @@ public class CollectionSerializers {
     }
 
     @Override
+    public Collection onCollectionWrite(MemoryBuffer buffer, T value) {
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public T onCollectionRead(Collection collection) {
+      throw new IllegalStateException();
+    }
+
+    @Override
     public void write(MemoryBuffer buffer, T value) {
       dataSerializer.write(buffer, value);
     }
@@ -529,8 +539,8 @@ public class CollectionSerializers {
   }
 
   /** Collection serializer for class with JDK custom serialization methods defined. */
-  public static final class JDKCompatibleCollectionSerializer<T extends Collection>
-      extends CollectionSerializer<T> {
+  public static final class JDKCompatibleCollectionSerializer<T>
+      extends AbstractCollectionSerializer<T> {
     private final Serializer serializer;
 
     public JDKCompatibleCollectionSerializer(Fury fury, Class<T> cls) {
@@ -544,10 +554,20 @@ public class CollectionSerializers {
       serializer = Serializers.newSerializer(fury, cls, serializerType);
     }
 
+    @Override
+    public Collection onCollectionWrite(MemoryBuffer buffer, T value) {
+      throw new IllegalStateException();
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public T read(MemoryBuffer buffer) {
       return (T) serializer.read(buffer);
+    }
+
+    @Override
+    public T onCollectionRead(Collection collection) {
+      throw new IllegalStateException();
     }
 
     @Override

--- a/java/fury-core/src/main/java/io/fury/serializer/collection/MapSerializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/collection/MapSerializers.java
@@ -328,7 +328,7 @@ public class MapSerializers {
    * won't use element generics and doesn't support JIT, performance won't be the best, but the
    * correctness can be ensured.
    */
-  public static final class DefaultJavaMapSerializer<T extends Map> extends MapSerializer<T> {
+  public static final class DefaultJavaMapSerializer<T> extends AbstractMapSerializer<T> {
     private Serializer<T> dataSerializer;
 
     public DefaultJavaMapSerializer(Fury fury, Class<T> cls) {
@@ -347,6 +347,16 @@ public class MapSerializers {
     }
 
     @Override
+    public Map onMapWrite(MemoryBuffer buffer, T value) {
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public T onMapRead(Map map) {
+      throw new IllegalStateException();
+    }
+
+    @Override
     public void write(MemoryBuffer buffer, T value) {
       dataSerializer.write(buffer, value);
     }
@@ -358,7 +368,7 @@ public class MapSerializers {
   }
 
   /** Map serializer for class with JDK custom serialization methods defined. */
-  public static class JDKCompatibleMapSerializer<T extends Map> extends MapSerializer<T> {
+  public static class JDKCompatibleMapSerializer<T> extends AbstractMapSerializer<T> {
     private final Serializer serializer;
 
     public JDKCompatibleMapSerializer(Fury fury, Class<T> cls) {
@@ -370,6 +380,16 @@ public class MapSerializers {
               ? ReplaceResolveSerializer.class
               : fury.getDefaultJDKStreamSerializerType();
       serializer = Serializers.newSerializer(fury, cls, serializerType);
+    }
+
+    @Override
+    public Map onMapWrite(MemoryBuffer buffer, T value) {
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public T onMapRead(Map map) {
+      throw new IllegalStateException();
     }
 
     @SuppressWarnings("unchecked")

--- a/scala/src/test/scala/io/fury/serializer/CollectionSerializerTest.scala
+++ b/scala/src/test/scala/io/fury/serializer/CollectionSerializerTest.scala
@@ -23,67 +23,45 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class CollectionSerializerTest extends AnyWordSpec with Matchers {
-  val fury1: Fury = Fury.builder()
-    .withLanguage(Language.JAVA)
-    .withRefTracking(true)
-    .withScalaOptimizationEnabled(false)
-    .requireClassRegistration(false).build()
-  fury1.getClassResolver.setSerializerFactory(null)
-  val fury2: Fury = Fury.builder()
-    .withLanguage(Language.JAVA)
-    .withRefTracking(true)
-    .withScalaOptimizationEnabled(true)
-    .requireClassRegistration(false).build()
-  fury2.getClassResolver.setSerializerFactory(new ScalaDispatcher())
-
-  "fury scala collection support noopt" should {
-    "serialize/deserialize Seq" in {
-      val seq = Seq(100, 10000L)
-      fury1.deserialize(fury1.serialize(seq)) shouldEqual seq
+  val params: Seq[(Boolean, Boolean)] = List((false, false), (false, true), (true, false), (true, true))
+  params.foreach{case (setOpt, setFactory) => {
+    val fury1: Fury = Fury.builder()
+      .withLanguage(Language.JAVA)
+      .withRefTracking(true)
+      .withScalaOptimizationEnabled(setOpt)
+      .requireClassRegistration(false).build()
+    if (setFactory) {
+      fury1.getClassResolver.setSerializerFactory(new ScalaDispatcher())
     }
-    "serialize/deserialize List" in {
-      val list = List(100, 10000L)
-      fury1.deserialize(fury1.serialize(list)) shouldEqual list
+    s"fury scala collection support: setOpt $setOpt, setFactory $setFactory" should {
+      "serialize/deserialize Seq" in {
+        val seq = Seq(100, 10000L)
+        fury1.deserialize(fury1.serialize(seq)) shouldEqual seq
+      }
+      "serialize/deserialize List" in {
+        val list = List(100, 10000L)
+        fury1.deserialize(fury1.serialize(list)) shouldEqual list
+      }
+      "serialize/deserialize Set" in {
+        val set = Set(100, 10000L)
+        fury1.deserialize(fury1.serialize(set)) shouldEqual set
+      }
+      "serialize/deserialize CollectionStruct1" in {
+        val struct = CollectionStruct1(List("a", "b"))
+        fury1.deserialize(fury1.serialize(struct)) shouldEqual struct
+      }
     }
-    "serialize/deserialize Set" in {
-      val set = Set(100, 10000L)
-      fury1.deserialize(fury1.serialize(set)) shouldEqual set
+    s"fury scala map support: setOpt $setOpt, setFactory $setFactory" should {
+      "serialize/deserialize Map" in {
+        val map = Map("a" -> 100, "b" -> 10000L)
+        fury1.deserialize(fury1.serialize(map)) shouldEqual map
+      }
+      "serialize/deserialize MapStruct1" in {
+        val struct = MapStruct1(Map("k1" -> "v1", "k2" -> "v2"))
+        fury1.deserialize(fury1.serialize(struct)) shouldEqual struct
+      }
     }
-  }
-  "fury scala collection support opt" should {
-    "serialize/deserialize Seq" in {
-      val seq = Seq(100, 10000L)
-      fury2.deserialize(fury2.serialize(seq)) shouldEqual seq
-    }
-    "serialize/deserialize List" in {
-      val list = List(100, 10000L)
-      fury2.deserialize(fury2.serialize(list)) shouldEqual list
-    }
-    "serialize/deserialize Set" in {
-      val set = Set(100, 10000L)
-      fury2.deserialize(fury2.serialize(set)) shouldEqual set
-    }
-    "serialize/deserialize CollectionStruct1" in {
-      val struct = CollectionStruct1(List("a", "b"))
-      fury2.deserialize(fury2.serialize(struct)) shouldEqual struct
-    }
-  }
-  "fury scala map support noopt" should {
-    "serialize/deserialize Map" in {
-      val map = Map("a" -> 100, "b" -> 10000L)
-      fury1.deserialize(fury1.serialize(map)) shouldEqual map
-    }
-  }
-  "fury scala map support opt" should {
-    "serialize/deserialize Map" in {
-      val map = Map("a" -> 100, "b" -> 10000L)
-      fury2.deserialize(fury2.serialize(map)) shouldEqual map
-    }
-    "serialize/deserialize MapStruct1" in {
-      val struct = MapStruct1(Map("k1" -> "v1", "k2" -> "v2"))
-      fury2.deserialize(fury2.serialize(struct)) shouldEqual struct
-    }
-  }
+  }}
 }
 
 case class CollectionStruct1(list: List[String])


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
When a class contains a field of scala list/map type, fury will returna ReplaceResolver serializer if `io.fury.serializer.scala.ScalaDispatcher` is not set, which will serializer CastException, since we assume all map/collection serializers all extends `AbstractMapSerializer/AbstractCollectionSerializer`
Fix scala collection serialization nested in pojo
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #1137 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
