### PR TITLE
[Java] make sting builder serializer codegen eager

### DIFF
--- a/java/fury-core/src/main/resources/META-INF/native-image/org.furyio/fury-core/native-image.properties
+++ b/java/fury-core/src/main/resources/META-INF/native-image/org.furyio/fury-core/native-image.properties
@@ -16,4 +16,5 @@
 # The unsafe offset get on build time may be different from runtime
 Args = --initialize-at-build-time=io.fury.util.Platform,io.fury.memory.MemoryBuffer,\
   io.fury.serializer.collection.UnmodifiableSerializers$Offset,\
-  io.fury.serializer.collection.SynchronizedSerializers$Offset
+  io.fury.serializer.collection.SynchronizedSerializers$Offset,\
+  io.fury.serializer.Serializers


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
 make sting builder serializer codegen eager to avoid graalvm create serializer exception at native image runtime:
```java
java.lang.InternalError: com.oracle.svm.core.jdk.UnsupportedFeatureError: Defining hidden classes at runtime is not supported.
	at java.base@17.0.9/java.lang.invoke.InnerClassLambdaMetafactory.generateInnerClass(InnerClassLambdaMetafactory.java:500)
	at java.base@17.0.9/java.lang.invoke.InnerClassLambdaMetafactory.spinInnerClass(InnerClassLambdaMetafactory.java:402)
	at java.base@17.0.9/java.lang.invoke.InnerClassLambdaMetafactory.buildCallSite(InnerClassLambdaMetafactory.java:315)
	at java.base@17.0.9/java.lang.invoke.LambdaMetafactory.metafactory(LambdaMetafactory.java:341)
	at io.fury.util.unsafe._JDKAccess.makeGetterFunction(_JDKAccess.java:283)
	at io.fury.util.function.Functions.makeGetterFunction(Functions.java:84)
	at io.fury.util.function.Functions.makeGetterFunction(Functions.java:71)
	at io.fury.serializer.Serializers.getBuilderFunc(Serializers.java:179)
	at io.fury.serializer.Serializers.access$000(Serializers.java:58)
	at io.fury.serializer.Serializers$AbstractStringBuilderSerializer.<init>(Serializers.java:200)
	at io.fury.serializer.Serializers$StringBuilderSerializer.<init>(Serializers.java:246)
	at io.fury.serializer.Serializers.registerDefaultSerializers(Serializers.java:557)
	at io.fury.resolver.ClassResolver.addDefaultSerializers(ClassResolver.java:324)
	at io.fury.resolver.ClassResolver.initialize(ClassResolver.java:314)
	at io.fury.Fury.<init>(Fury.java:131)
	at io.fury.config.FuryBuilder.newFury(FuryBuilder.java:297)
	at io.fury.config.FuryBuilder.lambda$buildThreadLocalFury$0(FuryBuilder.java:327)
	at io.fury.util.LoaderBinding.setClassLoader(LoaderBinding.java:93)
	at io.fury.util.LoaderBinding.setClassLoader(LoaderBinding.java:65)
	at io.fury.ThreadLocalFury.lambda$new$1(ThreadLocalFury.java:47)
	at java.base@17.0.9/java.lang.ThreadLocal$SuppliedThreadLocal.initialValue(ThreadLocal.java:305)
	at java.base@17.0.9/java.lang.ThreadLocal.setInitialValue(ThreadLocal.java:195)
	at java.base@17.0.9/java.lang.ThreadLocal.get(ThreadLocal.java:172)
	at io.fury.ThreadLocalFury.<init>(ThreadLocalFury.java:53)
	at io.fury.config.FuryBuilder.buildThreadLocalFury(FuryBuilder.java:327)
	at io.fury.config.FuryBuilder.buildThreadSafeFury(FuryBuilder.java:317)
	at me.ran.rumi.serializers.Serializers.<clinit>(Serializers.java:26)
```
<!-- Please give a short brief about these changes. -->


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
 #1115 #678 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
