### PR TITLE
[C++] Add duplicated fields detection in `FURY_FIELD_INFO` macro

### DIFF
--- a/src/fury/meta/BUILD
+++ b/src/fury/meta/BUILD
@@ -29,3 +29,13 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_test(
+    name = "type_traits_test",
+    srcs = ["type_traits_test.cc"],
+    copts = COPTS,
+    deps = [
+        ":fury_meta",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/src/fury/meta/type_traits.h
+++ b/src/fury/meta/type_traits.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace fury {
+
+namespace meta {
+
+// dependent name for constant `false` to workaround static_assert(false) issue
+// before C++23
+template <typename T> constexpr inline bool AlwaysFalse = false;
+
+// T U::* -> T
+template <typename> struct RemoveMemberPointer;
+
+template <typename T, typename U> struct RemoveMemberPointer<T U::*> {
+  using type = T;
+};
+
+template <typename T>
+using RemoveMemberPointerT = typename RemoveMemberPointer<T>::type;
+
+// same as std::remove_cvref_t since C++20
+template <typename T>
+using RemoveCVRefT = std::remove_cv_t<std::remove_reference_t<T>>;
+
+template <typename T>
+using RemoveMemberPointerCVRefT = RemoveMemberPointerT<RemoveCVRefT<T>>;
+
+template <auto V1, auto V2>
+inline constexpr bool IsSameValue =
+    std::is_same_v<std::integral_constant<decltype(V1), V1>,
+                   std::integral_constant<decltype(V2), V2>>;
+
+template <auto V, auto... Vs>
+inline constexpr bool ContainsValue =
+    std::disjunction_v<std::bool_constant<IsSameValue<V, Vs>>...>;
+
+template <auto...> struct IsUnique : std::true_type {};
+
+template <auto V1, auto... VN>
+struct IsUnique<V1, VN...>
+    : std::bool_constant<!ContainsValue<V1, VN...> && IsUnique<VN...>::value> {
+};
+
+} // namespace meta
+
+} // namespace fury

--- a/src/fury/meta/type_traits_test.cc
+++ b/src/fury/meta/type_traits_test.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+
+#include "fury/meta/field_info.h"
+#include "src/fury/meta/type_traits.h"
+
+namespace fury {
+
+namespace test {
+
+using namespace meta;
+
+struct A {
+  int x;
+  float y;
+};
+
+TEST(Meta, RemoveMemberPointer) {
+  static_assert(std::is_same_v<RemoveMemberPointerT<int A::*>, int>);
+  static_assert(std::is_same_v<RemoveMemberPointerT<bool A::*>, bool>);
+}
+
+TEST(Meta, IsSameValue) {
+  static_assert(IsSameValue<&A::x, &A::x>);
+  static_assert(!IsSameValue<&A::x, &A::y>);
+
+  static_assert(!IsSameValue<1, true>);
+  static_assert(IsSameValue<2, 2>);
+}
+
+TEST(Meta, ContainsValue) {
+  static_assert(ContainsValue<1, 1, 2, 3>);
+  static_assert(ContainsValue<2, 1, 2, 3>);
+  static_assert(ContainsValue<3, 1, 2, 3>);
+  static_assert(!ContainsValue<4, 1, 2, 3>);
+  static_assert(ContainsValue<true, 1, true, &A::x, 'a'>);
+  static_assert(ContainsValue<'a', 1, true, &A::x, 'a'>);
+  static_assert(!ContainsValue<0, 1, true, &A::x, 'a'>);
+}
+
+TEST(Meta, IsUnique) {
+  static_assert(IsUnique<1, 2, 3>::value);
+  static_assert(IsUnique<1, false, true, 3, &A::x>::value);
+  static_assert(!IsUnique<1, false, true, false, &A::x>::value);
+  static_assert(!IsUnique<1, false, true, &A::x, 1>::value);
+}
+
+} // namespace test
+
+} // namespace fury
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

It will prevent such code to be successfully compiled:
(previously, such code can be compiled without error, which make code error-prone.)
```c++
struct A {
  int x;
  float y;
};

FURY_FIELD_INFO(A, x, y, x); // compile error: duplicated fields in FURY_FIELD_INFO arguments are detected
```

Besides, we move type traits to `meta/type_traits.h`.