### PR TITLE
[C++] Support string type in RowEncoder

### DIFF
--- a/src/fury/encoder/row_encoder_test.cc
+++ b/src/fury/encoder/row_encoder_test.cc
@@ -57,6 +57,25 @@ TEST(RowEncoder, Simple) {
   ASSERT_EQ(row->GetBoolean(2), true);
 }
 
+struct B {
+  int num;
+  std::string str;
+};
+
+FURY_FIELD_INFO(B, num, str);
+
+TEST(RowEncoder, String) {
+  RowWriter writer(encoder::RowEncodeTrait<B>::Schema());
+  writer.Reset();
+
+  B b{233, "hello"};
+  encoder::RowEncodeTrait<B>::Write(b, writer);
+
+  auto row = writer.ToRow();
+  ASSERT_EQ(row->GetString(1), "hello");
+  ASSERT_EQ(row->GetInt32(0), 233);
+}
+
 } // namespace test
 
 } // namespace fury

--- a/src/fury/meta/type_traits.h
+++ b/src/fury/meta/type_traits.h
@@ -59,6 +59,18 @@ struct IsUnique<V1, VN...>
     : std::bool_constant<!ContainsValue<V1, VN...> && IsUnique<VN...>::value> {
 };
 
+template <auto> using Void = void;
+
+/// \brief Metafunction to allow checking if a type matches any of another set
+/// of types
+template <typename T, typename... Args>
+struct IsOneOf : std::disjunction<std::is_same<T, Args>...> {};
+
+/// \brief Shorthand for using IsOneOf + std::enable_if
+template <typename T, typename... Args>
+using EnableIfIsOneOf =
+    typename std::enable_if<IsOneOf<T, Args...>::value, T>::type;
+
 } // namespace meta
 
 } // namespace fury

--- a/src/fury/row/writer.cc
+++ b/src/fury/row/writer.cc
@@ -48,7 +48,7 @@ bool Writer::IsNullAt(int i) const {
                          static_cast<uint32_t>(i));
 }
 
-void Writer::WriteString(int i, const std::string &value) {
+void Writer::WriteString(int i, std::string_view value) {
   WriteBytes(i, reinterpret_cast<const uint8_t *>(value.data()),
              static_cast<int32_t>(value.size()));
 }

--- a/src/fury/row/writer.h
+++ b/src/fury/row/writer.h
@@ -92,7 +92,7 @@ public:
     buffer_->UnsafePut(GetOffset(i), value);
   }
 
-  void WriteString(int i, const std::string &value);
+  void WriteString(int i, std::string_view value);
 
   void WriteBytes(int i, const uint8_t *input, uint32_t length);
 

--- a/src/fury/util/BUILD
+++ b/src/fury/util/BUILD
@@ -11,6 +11,7 @@ cc_library(
     alwayslink=True,
     linkstatic=True,
     deps = [
+        "//src/fury/meta:fury_meta",
         "@com_google_absl//absl/debugging:failure_signal_handler",
         "@com_google_absl//absl/debugging:stacktrace",
         "@com_google_absl//absl/debugging:symbolize",

--- a/src/fury/util/buffer.h
+++ b/src/fury/util/buffer.h
@@ -90,7 +90,8 @@ public:
     reinterpret_cast<T *>(data_ + offset)[0] = value;
   }
 
-  template <typename T, typename = EnableIfIsOneOf<T, int8_t, uint8_t, bool>>
+  template <typename T,
+            typename = meta::EnableIfIsOneOf<T, int8_t, uint8_t, bool>>
   inline void UnsafePutByte(uint32_t offset, T value) {
     data_[offset] = value;
   }
@@ -107,7 +108,8 @@ public:
     return value;
   }
 
-  template <typename T, typename = EnableIfIsOneOf<T, int8_t, uint8_t, bool>>
+  template <typename T,
+            typename = meta::EnableIfIsOneOf<T, int8_t, uint8_t, bool>>
   inline T GetByteAs(uint32_t relative_offset) {
     FURY_CHECK(relative_offset < size_) << "Out of range " << relative_offset
                                         << " should be less than " << size_;

--- a/src/fury/util/util.h
+++ b/src/fury/util/util.h
@@ -24,6 +24,8 @@
 #include <string>
 #include <type_traits>
 
+#include "fury/meta/type_traits.h"
+
 #ifdef _WIN32
 #define ROW_LITTLE_ENDIAN 1
 #else
@@ -64,16 +66,6 @@
 #endif
 
 namespace fury {
-
-/// \brief Metafunction to allow checking if a type matches any of another set
-/// of types
-template <typename T, typename... Args>
-struct IsOneOf : std::disjunction<std::is_same<T, Args>...> {};
-
-/// \brief Shorthand for using IsOneOf + std::enable_if
-template <typename T, typename... Args>
-using EnableIfIsOneOf =
-    typename std::enable_if<IsOneOf<T, Args...>::value, T>::type;
 
 namespace BitUtil {
 
@@ -148,8 +140,9 @@ static inline void ByteSwap(void *dst, const void *src, int len) {
 
 // Convert to little/big endian format from the machine's native endian format.
 template <typename T>
-using IsEndianConvertibleType = IsOneOf<T, int64_t, uint64_t, int32_t, uint32_t,
-                                        int16_t, uint16_t, float, double>;
+using IsEndianConvertibleType =
+    meta::IsOneOf<T, int64_t, uint64_t, int32_t, uint32_t, int16_t, uint16_t,
+                  float, double>;
 
 template <typename T>
 using EnableIfIsEndianConvertibleType =


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

We support `std::string` and `std::string_view` in RowEncoder, e.g.
```c++
struct B {
  int num;
  std::string str;
};

FURY_FIELD_INFO(B, num, str);

RowWriter writer(encoder::RowEncodeTrait<B>::Schema());
writer.Reset();

B b{233, "hello"};
encoder::RowEncodeTrait<B>::Write(b, writer);
```

Besides, I move `IsOneOf` from `util` to `meta`.

And I think maybe we can rename `util.h` to something like `bit_util.h`, `time_util.h` and other `xxx_util.h`, so that it will not become a very messy source file that all developer want to put something into it since the name `util` is too general. cc @chaokunyang 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
