### PR TITLE
[Java] Remove load arrow serializers by default

### DIFF
--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -151,31 +151,6 @@ import org.slf4j.Logger;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ClassResolver {
   private static final Logger LOG = LoggerFactory.getLogger(ClassResolver.class);
-  private static final Class<Serializer> ArrowSerializersClass;
-
-  static {
-    List<String> splits = Arrays.asList(ClassResolver.class.getName().split("\\."));
-    String furyPackage = String.join(".", splits.subList(0, splits.size() - 2));
-    // compatible with maven shade.
-    String className = furyPackage + ".format.vectorized.ArrowSerializers";
-    Class<Serializer> cls = null;
-    try {
-      cls =
-          (Class<Serializer>) Class.forName(className, true, ClassResolver.class.getClassLoader());
-      LOG.debug("Loaded arrow serializer classes.");
-    } catch (ClassNotFoundException e) {
-      LOG.debug(
-          "`fury-format` dependency not included, skip adding serializer for class {}. "
-              + "If you want to use fury-format, please include fury-format dependency.",
-          className);
-    } catch (ExceptionInInitializerError | NoClassDefFoundError e) {
-      LOG.info(
-          "Add serializer for class {} failed. Apache arrow relies on the internals of `java.nio`. "
-              + "If you are using jdk17+, please open module `java.base` to unnamed module",
-          className);
-    }
-    ArrowSerializersClass = cls;
-  }
 
   // bit 0 unset indicates class is written as an id.
   public static final byte USE_CLASS_VALUE_FLAG = 0b1;
@@ -364,22 +339,6 @@ public class ClassResolver {
       Preconditions.checkArgument(classId > 63 && classId < 8192, classId);
     } else {
       register(UnexistedSkipClass.class);
-    }
-    if (ArrowSerializersClass != null) {
-      try {
-        Method method = ArrowSerializersClass.getDeclaredMethod("registerSerializers", Fury.class);
-        method.setAccessible(true);
-        method.invoke(null, fury);
-      } catch (NoSuchMethodException e) {
-        throw new IllegalStateException("unreachable", e);
-      } catch (InvocationTargetException | IllegalAccessException e) {
-        if (e instanceof InvocationTargetException) {
-          Throwable cause = e.getCause();
-          LOG.warn("Load arrow serialized failed at: ", cause);
-        } else {
-          throw new RuntimeException(e);
-        }
-      }
     }
   }
 

--- a/java/fury-format/src/test/java/io/fury/format/CrossLanguageTest.java
+++ b/java/fury-format/src/test/java/io/fury/format/CrossLanguageTest.java
@@ -28,12 +28,14 @@ import io.fury.format.encoder.Encoders;
 import io.fury.format.encoder.RowEncoder;
 import io.fury.format.row.binary.BinaryRow;
 import io.fury.format.type.DataTypes;
+import io.fury.format.vectorized.ArrowSerializers;
 import io.fury.format.vectorized.ArrowTable;
 import io.fury.format.vectorized.ArrowUtils;
 import io.fury.format.vectorized.ArrowWriter;
 import io.fury.io.FuryOutputStream;
 import io.fury.memory.MemoryBuffer;
 import io.fury.memory.MemoryUtils;
+import io.fury.serializer.ArraySerializers;
 import io.fury.serializer.BufferObject;
 import io.fury.util.LoggerFactory;
 import java.io.IOException;
@@ -366,6 +368,7 @@ public class CrossLanguageTest {
             .withRefTracking(true)
             .requireClassRegistration(false)
             .build();
+    ArrowSerializers.registerSerializers(fury);
     MemoryBuffer buffer = MemoryUtils.buffer(32);
     int size = 2000;
     VectorSchemaRoot root = createVectorSchemaRoot(size);
@@ -406,6 +409,7 @@ public class CrossLanguageTest {
             .withRefTracking(true)
             .requireClassRegistration(false)
             .build();
+    ArrowSerializers.registerSerializers(fury);
 
     MemoryBuffer buffer = MemoryUtils.buffer(32);
     int size = 2000;

--- a/java/fury-format/src/test/java/io/fury/format/vectorized/ArrowSerializersTest.java
+++ b/java/fury-format/src/test/java/io/fury/format/vectorized/ArrowSerializersTest.java
@@ -45,10 +45,7 @@ public class ArrowSerializersTest {
   public void testRegisterArrowSerializer() throws Exception {
     Fury fury = Fury.builder().withLanguage(Language.JAVA).build();
     ClassResolver classResolver = fury.getClassResolver();
-    Field field = ClassResolver.class.getDeclaredField("ArrowSerializersClass");
-    field.setAccessible(true);
-    Object arrowSerializersClass = field.get(null);
-    assertSame(arrowSerializersClass, ArrowSerializers.class);
+    ArrowSerializers.registerSerializers(fury);
     assertEquals(classResolver.getSerializerClass(ArrowTable.class), ArrowTableSerializer.class);
     assertEquals(
         classResolver.getSerializerClass(VectorSchemaRoot.class),
@@ -59,6 +56,7 @@ public class ArrowSerializersTest {
   public void testWriteVectorSchemaRoot() throws IOException {
     Collection<BufferObject> bufferObjects = new ArrayList<>();
     Fury fury = Fury.builder().requireClassRegistration(false).build();
+    ArrowSerializers.registerSerializers(fury);
     int size = 2000;
     VectorSchemaRoot root = ArrowUtilsTest.createVectorSchemaRoot(size);
     Assert.assertEquals(
@@ -84,6 +82,7 @@ public class ArrowSerializersTest {
 
     // test in band serialization.
     fury = Fury.builder().requireClassRegistration(false).build();
+    ArrowSerializers.registerSerializers(fury);
     newRoot = (VectorSchemaRoot) fury.deserialize(fury.serialize(root));
     assertRecordBatchEqual(newRoot, root);
   }
@@ -92,6 +91,7 @@ public class ArrowSerializersTest {
   public void testWriteArrowTable() throws IOException {
     Collection<BufferObject> bufferObjects = new ArrayList<>();
     Fury fury = Fury.builder().requireClassRegistration(false).build();
+    ArrowSerializers.registerSerializers(fury);
     int size = 2000;
     VectorSchemaRoot root = ArrowUtilsTest.createVectorSchemaRoot(size);
     Schema schema = root.getSchema();
@@ -114,6 +114,7 @@ public class ArrowSerializersTest {
 
     // test in band serialization.
     fury = Fury.builder().requireClassRegistration(false).build();
+    ArrowSerializers.registerSerializers(fury);
     newTable = (ArrowTable) fury.deserialize(fury.serialize(table));
     assertTableEqual(newTable, table);
   }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Remove load arrow serializers by default
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #1162

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
