### PR TITLE
[Java] Support thread safe fury for graalvm native image

### DIFF
--- a/integration_tests/graalvm_tests/src/main/java/io/fury/graalvm/Main.java
+++ b/integration_tests/graalvm_tests/src/main/java/io/fury/graalvm/Main.java
@@ -24,7 +24,6 @@ public class Main {
     Example.main(args);
     RecordExample.main(args);
     RecordExample2.main(args);
-    // TODO support ThreadSafeFury in future.
-    // ThreadSafeExample.main(args);
+    ThreadSafeExample.main(args);
   }
 }

--- a/integration_tests/graalvm_tests/src/main/java/io/fury/graalvm/ThreadSafeExample.java
+++ b/integration_tests/graalvm_tests/src/main/java/io/fury/graalvm/ThreadSafeExample.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.graalvm;
+
+import io.fury.Fury;
+import io.fury.ThreadLocalFury;
+import io.fury.ThreadSafeFury;
+import io.fury.collection.Collections;
+import io.fury.util.Preconditions;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class ThreadSafeExample {
+  static ThreadSafeFury fury;
+
+  static {
+    fury = new ThreadLocalFury(classLoader -> {
+      Fury f = Fury.builder().requireClassRegistration(true).build();
+      // register and generate serializer code.
+      f.register(Foo.class, true);
+      return f;
+    });
+    System.out.println("Init fury at build time");
+  }
+
+  public static void main(String[] args) throws Throwable {
+    ThreadSafeExample threadSafeExample = new ThreadSafeExample();
+    threadSafeExample.test();
+    System.out.println("single thread works");
+    ExecutorService service = Executors.newFixedThreadPool(10);
+    System.out.println("Start to submit tasks");
+    for (int i = 0; i < 1000; i++) {
+      service.submit(() -> {
+        try {
+          threadSafeExample.test();
+        } catch (Throwable t) {
+          threadSafeExample.throwable = t;
+        }
+      });
+    }
+    Thread.sleep(3000);
+    service.shutdown();
+    service.awaitTermination(10, TimeUnit.SECONDS);
+    System.out.println("tasks finished");
+    if (threadSafeExample.throwable != null) {
+      throw threadSafeExample.throwable;
+    }
+    System.out.println("tasks finished succeed");
+  }
+
+  private volatile Throwable throwable;
+
+  private  void test() {
+    Preconditions.checkArgument("abc".equals(fury.deserialize(fury.serialize("abc"))));
+    Preconditions.checkArgument(List.of(1,2,3).equals(fury.deserialize(fury.serialize(List.of(1,2,3)))));
+    List<String> list = Collections.ofArrayList("a", "b", "c");
+    Preconditions.checkArgument(list.equals(fury.deserialize(fury.serialize(list))));
+    Map<String, Integer> map = Collections.ofHashMap("k1", 1, "k2", 2);
+    Preconditions.checkArgument(map.equals(fury.deserialize(fury.serialize(map))));
+    map = Map.of("k1", 1, "k2", 2);
+    Preconditions.checkArgument(map.equals(fury.deserialize(fury.serialize(map))));
+    Foo foo = new Foo(10, "abc", List.of("str1", "str2"), Map.of("k1", 10L, "k2", 20L));
+    Object o = fury.deserialize(fury.serialize(foo));
+    Preconditions.checkArgument(foo.equals(o));
+  }
+}

--- a/java/fury-core/src/main/java/io/fury/Fury.java
+++ b/java/fury-core/src/main/java/io/fury/Fury.java
@@ -44,7 +44,6 @@ import io.fury.type.Generics;
 import io.fury.type.Type;
 import io.fury.util.ExceptionUtils;
 import io.fury.util.LoggerFactory;
-import io.fury.util.Platform;
 import io.fury.util.Preconditions;
 import io.fury.util.StringUtils;
 import java.io.ByteArrayInputStream;
@@ -302,8 +301,6 @@ public final class Fury {
   }
 
   private MemoryBuffer getBuffer() {
-    assert !Platform.IS_GRAALVM_IMAGE_BUILD_TIME
-        : "MemoryBuffer is not allowed for creation in graalvm build time";
     MemoryBuffer buf = buffer;
     if (buf == null) {
       buf = buffer = MemoryBuffer.newHeapBuffer(64);

--- a/java/fury-core/src/main/java/io/fury/ThreadLocalFury.java
+++ b/java/fury-core/src/main/java/io/fury/ThreadLocalFury.java
@@ -18,6 +18,7 @@ package io.fury;
 
 import io.fury.memory.MemoryBuffer;
 import io.fury.memory.MemoryUtils;
+import io.fury.resolver.ClassResolver;
 import io.fury.util.LoaderBinding;
 import io.fury.util.LoaderBinding.StagingType;
 import java.nio.ByteBuffer;
@@ -33,7 +34,6 @@ import javax.annotation.concurrent.ThreadSafe;
  */
 @ThreadSafe
 public class ThreadLocalFury implements ThreadSafeFury {
-
   private final ThreadLocal<MemoryBuffer> bufferLocal =
       ThreadLocal.withInitial(() -> MemoryUtils.buffer(32));
 
@@ -51,7 +51,9 @@ public class ThreadLocalFury implements ThreadSafeFury {
     // Fury creation took about 1~2 ms, but first creation
     // in a process load some classes which is not cheap.
     // 2. Make fury generate code at graalvm build time.
-    bindingThreadLocal.get().get();
+    Fury fury = bindingThreadLocal.get().get();
+    ClassResolver._addGraalvmClassRegistry(
+      fury.getConfig().getConfigHash(), fury.getClassResolver());
   }
 
   public <R> R execute(Function<Fury, R> action) {

--- a/java/fury-core/src/main/java/io/fury/ThreadLocalFury.java
+++ b/java/fury-core/src/main/java/io/fury/ThreadLocalFury.java
@@ -53,7 +53,7 @@ public class ThreadLocalFury implements ThreadSafeFury {
     // 2. Make fury generate code at graalvm build time.
     Fury fury = bindingThreadLocal.get().get();
     ClassResolver._addGraalvmClassRegistry(
-      fury.getConfig().getConfigHash(), fury.getClassResolver());
+        fury.getConfig().getConfigHash(), fury.getClassResolver());
   }
 
   public <R> R execute(Function<Fury, R> action) {

--- a/java/fury-core/src/main/java/io/fury/builder/BaseObjectCodecBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/builder/BaseObjectCodecBuilder.java
@@ -81,7 +81,7 @@ import io.fury.serializer.StringSerializer;
 import io.fury.serializer.collection.AbstractCollectionSerializer;
 import io.fury.serializer.collection.AbstractMapSerializer;
 import io.fury.type.TypeUtils;
-import io.fury.util.Platform;
+import io.fury.util.GraalvmSupport;
 import io.fury.util.Preconditions;
 import io.fury.util.ReflectionUtils;
 import io.fury.util.StringUtils;
@@ -1488,7 +1488,7 @@ public abstract class BaseObjectCodecBuilder extends CodecBuilder {
 
   @Override
   protected Expression beanClassExpr() {
-    if (Platform.IS_GRAALVM_IMAGE_BUILD_TIME) {
+    if (GraalvmSupport.isGraalBuildtime()) {
       return staticBeanClassExpr();
     }
     // Serializer has a `type` field.

--- a/java/fury-core/src/main/java/io/fury/builder/CodecBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/builder/CodecBuilder.java
@@ -49,6 +49,7 @@ import io.fury.resolver.ClassInfo;
 import io.fury.resolver.ClassInfoHolder;
 import io.fury.type.Descriptor;
 import io.fury.type.FinalObjectTypeStub;
+import io.fury.util.GraalvmSupport;
 import io.fury.util.Platform;
 import io.fury.util.Preconditions;
 import io.fury.util.ReflectionUtils;
@@ -314,7 +315,7 @@ public abstract class CodecBuilder {
     Field field = descriptor.getField();
     String fieldName = descriptor.getName();
     // Use Field in case the class has duplicate field name as `fieldName`.
-    if (Platform.IS_GRAALVM_IMAGE_BUILD_TIME) {
+    if (GraalvmSupport.isGraalBuildtime()) {
       return getOrCreateField(
           true,
           long.class,
@@ -426,7 +427,7 @@ public abstract class CodecBuilder {
           TypeToken<Field> fieldTypeToken = TypeToken.of(Field.class);
           Expression classExpr = beanClassExpr(field.getDeclaringClass());
           Expression fieldExpr;
-          if (Platform.IS_GRAALVM_IMAGE_BUILD_TIME) {
+          if (GraalvmSupport.isGraalBuildtime()) {
             fieldExpr =
                 inlineInvoke(
                     classExpr, "getDeclaredField", fieldTypeToken, Literal.ofString(fieldName));
@@ -496,7 +497,7 @@ public abstract class CodecBuilder {
     if (cls == beanClass) {
       return staticBeanClassExpr();
     }
-    if (Platform.IS_GRAALVM_IMAGE_BUILD_TIME) {
+    if (GraalvmSupport.isGraalBuildtime()) {
       String name = cls.getName().replaceAll("\\.|\\$", "_") + "__class__";
       return getOrCreateField(
           true,
@@ -514,7 +515,7 @@ public abstract class CodecBuilder {
   }
 
   protected Expression beanClassExpr() {
-    if (Platform.IS_GRAALVM_IMAGE_BUILD_TIME) {
+    if (GraalvmSupport.isGraalBuildtime()) {
       return staticBeanClassExpr();
     }
     throw new UnsupportedOperationException();

--- a/java/fury-core/src/main/java/io/fury/codegen/CodeGenerator.java
+++ b/java/fury-core/src/main/java/io/fury/codegen/CodeGenerator.java
@@ -25,8 +25,8 @@ import io.fury.builder.Generated;
 import io.fury.collection.MultiKeyWeakMap;
 import io.fury.util.ClassLoaderUtils;
 import io.fury.util.ClassLoaderUtils.ByteArrayClassLoader;
+import io.fury.util.GraalvmSupport;
 import io.fury.util.LoggerFactory;
-import io.fury.util.Platform;
 import io.fury.util.Preconditions;
 import io.fury.util.ReflectionUtils;
 import io.fury.util.StringUtils;
@@ -230,7 +230,7 @@ public class CodeGenerator {
 
   public static synchronized ListeningExecutorService getCompilationService() {
     if (compilationExecutorService == null) {
-      if (Platform.IS_GRAALVM_IMAGE_BUILD_TIME) {
+      if (GraalvmSupport.isGraalBuildtime()) {
         // GraalVM build time can't reachable thread.
         return compilationExecutorService = MoreExecutors.newDirectExecutorService();
       }

--- a/java/fury-core/src/main/java/io/fury/collection/MultiKeyWeakMap.java
+++ b/java/fury-core/src/main/java/io/fury/collection/MultiKeyWeakMap.java
@@ -18,7 +18,7 @@ package io.fury.collection;
 
 import com.google.common.base.FinalizableReferenceQueue;
 import com.google.common.base.FinalizableWeakReference;
-import io.fury.util.Platform;
+import io.fury.util.GraalvmSupport;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,7 +42,7 @@ public class MultiKeyWeakMap<T> {
   private static final FinalizableReferenceQueue REFERENCE_QUEUE;
 
   static {
-    if (Platform.IS_GRAALVM_IMAGE_BUILD_TIME) {
+    if (GraalvmSupport.isGraalBuildtime()) {
       REFERENCE_QUEUE = null;
     } else {
       REFERENCE_QUEUE = new FinalizableReferenceQueue();
@@ -69,7 +69,7 @@ public class MultiKeyWeakMap<T> {
 
   private List<? extends KeyReference> createKey(Object[] keys) {
     boolean[] reclaimedFlags = new boolean[keys.length];
-    if (Platform.IS_GRAALVM_IMAGE_BUILD_TIME) {
+    if (GraalvmSupport.isGraalBuildtime()) {
       List<NoCallbackRef> keyRefs = new ArrayList<>();
       for (Object key : keys) {
         keyRefs.add(new NoCallbackRef(key));

--- a/java/fury-core/src/main/java/io/fury/config/Config.java
+++ b/java/fury-core/src/main/java/io/fury/config/Config.java
@@ -209,8 +209,12 @@ public class Config implements Serializable {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     Config config = (Config) o;
     return trackingRef == config.trackingRef
         && basicTypesRefIgnored == config.basicTypesRefIgnored

--- a/java/fury-core/src/main/java/io/fury/memory/MemoryBuffer.java
+++ b/java/fury-core/src/main/java/io/fury/memory/MemoryBuffer.java
@@ -53,8 +53,8 @@ import java.util.Arrays;
  * part as separate class, and use composition in this class. In this way, all fields can be final
  * and access will be much faster.
  *
- * <p>The instance of this class should not be hold on graalvm build time, the heap unsafe offset
- * are not correct in runtime since graalvm will change array base offset.
+ * <p>Warning: The instance of this class should not be hold on graalvm build time, the heap unsafe
+ * offset are not correct in runtime since graalvm will change array base offset.
  */
 // FIXME Buffer operations is most common, and jvm inline and branch elimination
 // is not reliable even in c2 compiler, so we try to inline and avoid checks as we can manually.
@@ -104,8 +104,6 @@ public final class MemoryBuffer {
    */
   private MemoryBuffer(byte[] buffer, int offset, int length) {
     Preconditions.checkArgument(offset >= 0 && length >= 0);
-    assert !Platform.IS_GRAALVM_IMAGE_BUILD_TIME
-        : "MemoryBuffer is not allowed for creation in graalvm build time";
     if (offset + length > buffer.length) {
       throw new IllegalArgumentException(
           String.format("%d exceeds buffer size %d", offset + length, buffer.length));

--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -131,6 +131,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -782,6 +783,7 @@ public class ClassResolver {
   }
 
   public Class<? extends Serializer> getSerializerClass(Class<?> cls) {
+
     boolean codegen =
         supportCodegenForJavaSerialization(cls) && fury.getConfig().isCodeGenEnabled();
     return getSerializerClass(cls, codegen);
@@ -791,6 +793,10 @@ public class ClassResolver {
     if (ReflectionUtils.isAbstract(cls) || cls.isInterface()) {
       throw new UnsupportedOperationException(
           String.format("Class %s doesn't support serialization.", cls));
+    }
+    Class<? extends Serializer> serializerClass = getSerializerClassFromGraalvmRegistry(cls);
+    if (serializerClass != null) {
+      return serializerClass;
     }
     cls = TypeUtils.boxedType(cls);
     ClassInfo classInfo = classInfoMap.get(cls);
@@ -843,8 +849,7 @@ public class ClassResolver {
       if (isCollection(cls)) {
         // Serializer of common collection such as ArrayList/LinkedList should be registered
         // already.
-        Class<? extends Serializer> serializerClass =
-            ChildContainerSerializers.getCollectionSerializerClass(cls);
+        serializerClass = ChildContainerSerializers.getCollectionSerializerClass(cls);
         if (serializerClass != null) {
           return serializerClass;
         }
@@ -858,8 +863,7 @@ public class ClassResolver {
         }
       } else if (isMap(cls)) {
         // Serializer of common map such as HashMap/LinkedHashMap should be registered already.
-        Class<? extends Serializer> serializerClass =
-            ChildContainerSerializers.getMapSerializerClass(cls);
+        serializerClass = ChildContainerSerializers.getMapSerializerClass(cls);
         if (serializerClass != null) {
           return serializerClass;
         }
@@ -1789,5 +1793,25 @@ public class ClassResolver {
 
   public Fury getFury() {
     return fury;
+  }
+
+  private static final ConcurrentMap<Integer, ClassResolver> GRAALVM_REGISTRY = new ConcurrentHashMap<>();
+
+  // CHECKSTYLE.OFF:MethodName
+  public static void _addGraalvmClassRegistry(int furyConfigHash, ClassResolver classResolver) {
+    // CHECKSTYLE.ON:MethodName
+    GRAALVM_REGISTRY.put(furyConfigHash, classResolver);
+  }
+
+  private Class<? extends Serializer> getSerializerClassFromGraalvmRegistry(Class<?> cls) {
+    if (Platform.IS_GRAALVM_IMAGE_RUN_TIME) {
+      ClassResolver classResolver = GRAALVM_REGISTRY.get(fury.getConfig().getConfigHash());
+      if (classResolver != null && classResolver != this) {
+        ClassInfo classInfo = classResolver.classInfoMap.get(cls);
+        Preconditions.checkArgument(classInfo != null, "Class %s is not registered", cls);
+        return Objects.requireNonNull(classInfo).serializer.getClass();
+      }
+    }
+    return null;
   }
 }

--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -1795,7 +1795,8 @@ public class ClassResolver {
     return fury;
   }
 
-  private static final ConcurrentMap<Integer, ClassResolver> GRAALVM_REGISTRY = new ConcurrentHashMap<>();
+  private static final ConcurrentMap<Integer, ClassResolver> GRAALVM_REGISTRY =
+      new ConcurrentHashMap<>();
 
   // CHECKSTYLE.OFF:MethodName
   public static void _addGraalvmClassRegistry(int furyConfigHash, ClassResolver classResolver) {

--- a/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
+++ b/java/fury-core/src/main/java/io/fury/resolver/ClassResolver.java
@@ -86,6 +86,7 @@ import io.fury.type.Descriptor;
 import io.fury.type.GenericType;
 import io.fury.type.ScalaTypes;
 import io.fury.type.TypeUtils;
+import io.fury.util.GraalvmSupport;
 import io.fury.util.LoggerFactory;
 import io.fury.util.Platform;
 import io.fury.util.Preconditions;
@@ -1801,17 +1802,17 @@ public class ClassResolver {
   // CHECKSTYLE.OFF:MethodName
   public static void _addGraalvmClassRegistry(int furyConfigHash, ClassResolver classResolver) {
     // CHECKSTYLE.ON:MethodName
-    GRAALVM_REGISTRY.put(furyConfigHash, classResolver);
+    if (GraalvmSupport.isGraalBuildtime()) {
+      GRAALVM_REGISTRY.put(furyConfigHash, classResolver);
+    }
   }
 
   private Class<? extends Serializer> getSerializerClassFromGraalvmRegistry(Class<?> cls) {
-    if (Platform.IS_GRAALVM_IMAGE_RUN_TIME) {
-      ClassResolver classResolver = GRAALVM_REGISTRY.get(fury.getConfig().getConfigHash());
-      if (classResolver != null && classResolver != this) {
-        ClassInfo classInfo = classResolver.classInfoMap.get(cls);
-        Preconditions.checkArgument(classInfo != null, "Class %s is not registered", cls);
-        return Objects.requireNonNull(classInfo).serializer.getClass();
-      }
+    ClassResolver classResolver = GRAALVM_REGISTRY.get(fury.getConfig().getConfigHash());
+    if (classResolver != null && classResolver != this) {
+      ClassInfo classInfo = classResolver.classInfoMap.get(cls);
+      Preconditions.checkArgument(classInfo != null, "Class %s is not registered", cls);
+      return Objects.requireNonNull(classInfo).serializer.getClass();
     }
     return null;
   }

--- a/java/fury-core/src/main/java/io/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/Serializers.java
@@ -60,7 +60,7 @@ import java.util.regex.Pattern;
 public class Serializers {
   // avoid duplicate reflect inspection and cache for graalvm support too.
   private static final ConcurrentMap<Class, Tuple2<MethodType, MethodHandle>> CTR_MAP =
-    new ConcurrentHashMap<>();
+      new ConcurrentHashMap<>();
   private static final MethodType SIG1 = MethodType.methodType(void.class, Fury.class, Class.class);
   private static final MethodType SIG2 = MethodType.methodType(void.class, Fury.class);
   private static final MethodType SIG3 = MethodType.methodType(void.class, Class.class);
@@ -114,7 +114,7 @@ public class Serializers {
   }
 
   private static <T> Serializer<T> createSerializer(
-    Fury fury, Class<?> type, Class<? extends Serializer> serializerClass) throws Throwable {
+      Fury fury, Class<?> type, Class<? extends Serializer> serializerClass) throws Throwable {
     MethodHandles.Lookup lookup = _JDKAccess._trustedLookup(serializerClass);
     try {
       MethodHandle ctr = lookup.findConstructor(serializerClass, SIG1);

--- a/java/fury-core/src/main/java/io/fury/serializer/Serializers.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/Serializers.java
@@ -80,7 +80,7 @@ public class Serializers {
       if (serializerClass == CompatibleSerializer.class) {
         return new CompatibleSerializer(fury, type);
       }
-      Tuple2<MethodType, MethodHandle> ctrInfo = CTR_MAP.get(type);
+      Tuple2<MethodType, MethodHandle> ctrInfo = CTR_MAP.get(serializerClass);
       if (ctrInfo != null) {
         MethodType sig = ctrInfo.f0;
         MethodHandle handle = ctrInfo.f1;
@@ -115,29 +115,28 @@ public class Serializers {
 
   private static <T> Serializer<T> createSerializer(
     Fury fury, Class<?> type, Class<? extends Serializer> serializerClass) throws Throwable {
-    // reflection
     MethodHandles.Lookup lookup = _JDKAccess._trustedLookup(serializerClass);
     try {
       MethodHandle ctr = lookup.findConstructor(serializerClass, SIG1);
-      CTR_MAP.put(type, Tuple2.of(SIG1, ctr));
+      CTR_MAP.put(serializerClass, Tuple2.of(SIG1, ctr));
       return (Serializer<T>) ctr.invoke(fury, type);
     } catch (NoSuchMethodException e) {
       Utils.ignore(e);
     }
     try {
       MethodHandle ctr = lookup.findConstructor(serializerClass, SIG2);
-      CTR_MAP.put(type, Tuple2.of(SIG2, ctr));
+      CTR_MAP.put(serializerClass, Tuple2.of(SIG2, ctr));
       return (Serializer<T>) ctr.invoke(fury);
     } catch (NoSuchMethodException e) {
       Utils.ignore(e);
     }
     try {
       MethodHandle ctr = lookup.findConstructor(serializerClass, SIG3);
-      CTR_MAP.put(type, Tuple2.of(SIG3, ctr));
+      CTR_MAP.put(serializerClass, Tuple2.of(SIG3, ctr));
       return (Serializer<T>) ctr.invoke(type);
     } catch (NoSuchMethodException e) {
       MethodHandle ctr = ReflectionUtils.getCtrHandle(serializerClass);
-      CTR_MAP.put(type, Tuple2.of(SIG4, ctr));
+      CTR_MAP.put(serializerClass, Tuple2.of(SIG4, ctr));
       return (Serializer<T>) ctr.invoke();
     }
   }

--- a/java/fury-core/src/main/java/io/fury/serializer/scala/SingletonCollectionSerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/scala/SingletonCollectionSerializer.java
@@ -19,6 +19,7 @@ package io.fury.serializer.scala;
 import io.fury.Fury;
 import io.fury.memory.MemoryBuffer;
 import io.fury.serializer.collection.AbstractCollectionSerializer;
+import io.fury.util.GraalvmSupport;
 import io.fury.util.Platform;
 import io.fury.util.Preconditions;
 import java.lang.reflect.Field;
@@ -57,7 +58,7 @@ public class SingletonCollectionSerializer extends AbstractCollectionSerializer 
   public Object read(MemoryBuffer buffer) {
     long offset = this.offset;
     if (offset == -1) {
-      Preconditions.checkArgument(!Platform.IS_GRAALVM_IMAGE_BUILD_TIME);
+      Preconditions.checkArgument(!GraalvmSupport.isGraalBuildtime());
       offset = this.offset = Platform.UNSAFE.staticFieldOffset(field);
     }
     return Platform.getObject(type, offset);

--- a/java/fury-core/src/main/java/io/fury/serializer/scala/SingletonMapSerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/scala/SingletonMapSerializer.java
@@ -19,6 +19,7 @@ package io.fury.serializer.scala;
 import io.fury.Fury;
 import io.fury.memory.MemoryBuffer;
 import io.fury.serializer.collection.AbstractMapSerializer;
+import io.fury.util.GraalvmSupport;
 import io.fury.util.Platform;
 import io.fury.util.Preconditions;
 import java.lang.reflect.Field;
@@ -57,7 +58,7 @@ public class SingletonMapSerializer extends AbstractMapSerializer {
   public Object read(MemoryBuffer buffer) {
     long offset = this.offset;
     if (offset == -1) {
-      Preconditions.checkArgument(!Platform.IS_GRAALVM_IMAGE_BUILD_TIME);
+      Preconditions.checkArgument(!GraalvmSupport.isGraalBuildtime());
       offset = this.offset = Platform.UNSAFE.staticFieldOffset(field);
     }
     return Platform.getObject(type, offset);

--- a/java/fury-core/src/main/java/io/fury/serializer/scala/SingletonObjectSerializer.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/scala/SingletonObjectSerializer.java
@@ -19,6 +19,7 @@ package io.fury.serializer.scala;
 import io.fury.Fury;
 import io.fury.memory.MemoryBuffer;
 import io.fury.serializer.Serializer;
+import io.fury.util.GraalvmSupport;
 import io.fury.util.Platform;
 import io.fury.util.Preconditions;
 import java.lang.reflect.Field;
@@ -50,7 +51,7 @@ public class SingletonObjectSerializer extends Serializer {
   public Object read(MemoryBuffer buffer) {
     long offset = this.offset;
     if (offset == -1) {
-      Preconditions.checkArgument(!Platform.IS_GRAALVM_IMAGE_BUILD_TIME);
+      Preconditions.checkArgument(!GraalvmSupport.isGraalBuildtime());
       offset = this.offset = Platform.UNSAFE.staticFieldOffset(field);
     }
     return Platform.getObject(type, offset);

--- a/java/fury-core/src/main/java/io/fury/serializer/shim/ShimDispatcher.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/shim/ShimDispatcher.java
@@ -24,8 +24,6 @@ import io.fury.serializer.Serializers;
 import io.fury.serializer.collection.CollectionSerializer;
 import io.fury.serializer.collection.MapSerializers;
 import io.fury.util.Preconditions;
-import io.fury.util.ReflectionUtils;
-import java.lang.invoke.MethodHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/java/fury-core/src/main/java/io/fury/serializer/shim/ShimDispatcher.java
+++ b/java/fury-core/src/main/java/io/fury/serializer/shim/ShimDispatcher.java
@@ -20,6 +20,7 @@ import io.fury.Fury;
 import io.fury.collection.FuryObjectMap;
 import io.fury.collection.ObjectMap;
 import io.fury.serializer.Serializer;
+import io.fury.serializer.Serializers;
 import io.fury.serializer.collection.CollectionSerializer;
 import io.fury.serializer.collection.MapSerializers;
 import io.fury.util.Preconditions;
@@ -77,9 +78,7 @@ public class ShimDispatcher {
     }
     Class<? extends Serializer> serializerClass = className2ShimSerializerClass.get(className);
     try {
-      MethodHandle ctrHandle =
-          ReflectionUtils.getCtrHandle(serializerClass, Fury.class, Class.class);
-      return (Serializer<?>) ctrHandle.invoke(fury, clazz);
+      return Serializers.newSerializer(fury, clazz, serializerClass);
     } catch (Throwable e) {
       LOG.warn(
           "Construct shim serializer failed for class [{}] with serializer class [{}]",

--- a/java/fury-core/src/main/java/io/fury/util/GraalvmSupport.java
+++ b/java/fury-core/src/main/java/io/fury/util/GraalvmSupport.java
@@ -36,17 +36,13 @@ public class GraalvmSupport {
     IN_GRAALVM_NATIVE_IMAGE = imageCode != null;
   }
 
-  /**
-   * Returns true if current process is running in graalvm native image build stage.
-   */
+  /** Returns true if current process is running in graalvm native image build stage. */
   public static boolean isGraalBuildtime() {
     return IN_GRAALVM_NATIVE_IMAGE
         && GRAAL_IMAGE_BUILDTIME.equals(System.getProperty(GRAAL_IMAGE_CODE_KEY));
   }
 
-  /**
-   * Returns true if current process is running in graalvm native image runtime stage.
-   */
+  /** Returns true if current process is running in graalvm native image runtime stage. */
   public static boolean isGraalRuntime() {
     return IN_GRAALVM_NATIVE_IMAGE
         && GRAAL_IMAGE_RUNTIME.equals(System.getProperty(GRAAL_IMAGE_CODE_KEY));

--- a/java/fury-core/src/main/java/io/fury/util/GraalvmSupport.java
+++ b/java/fury-core/src/main/java/io/fury/util/GraalvmSupport.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.fury.util;
+
+/**
+ * A helper for Graalvm native image support.
+ *
+ * @author chaokunyang
+ */
+public class GraalvmSupport {
+  // https://github.com/oracle/graal/blob/master/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/ImageInfo.java
+  public static final boolean IN_GRAALVM_NATIVE_IMAGE;
+  // We can't cache code key or isBuildTime as static constant, since this class will be initialized
+  // at build time,
+  // and will be still build time value when it's graalvm runtime actually.
+  private static final String GRAAL_IMAGE_CODE_KEY = "org.graalvm.nativeimage.imagecode";
+  private static final String GRAAL_IMAGE_BUILDTIME = "buildtime";
+  private static final String GRAAL_IMAGE_RUNTIME = "runtime";
+
+  static {
+    String imageCode = System.getProperty(GRAAL_IMAGE_CODE_KEY);
+    IN_GRAALVM_NATIVE_IMAGE = imageCode != null;
+  }
+
+  /**
+   * Returns true if current process is running in graalvm native image build stage.
+   */
+  public static boolean isGraalBuildtime() {
+    return IN_GRAALVM_NATIVE_IMAGE
+        && GRAAL_IMAGE_BUILDTIME.equals(System.getProperty(GRAAL_IMAGE_CODE_KEY));
+  }
+
+  /**
+   * Returns true if current process is running in graalvm native image runtime stage.
+   */
+  public static boolean isGraalRuntime() {
+    return IN_GRAALVM_NATIVE_IMAGE
+        && GRAAL_IMAGE_RUNTIME.equals(System.getProperty(GRAAL_IMAGE_CODE_KEY));
+  }
+}

--- a/java/fury-core/src/main/java/io/fury/util/Platform.java
+++ b/java/fury-core/src/main/java/io/fury/util/Platform.java
@@ -35,8 +35,6 @@ public final class Platform {
   public static final Unsafe UNSAFE = _JDKAccess.UNSAFE;
 
   public static final int JAVA_VERSION = _JDKAccess.JAVA_VERSION;
-  public static final boolean IS_GRAALVM_IMAGE_BUILD_TIME = _JDKAccess.IS_GRAALVM_IMAGE_BUILD_TIME;
-  public static final boolean IS_GRAALVM_IMAGE_RUN_TIME = _JDKAccess.IS_GRAALVM_IMAGE_RUN_TIME;
   public static final boolean IS_LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
 
   public static final int BOOLEAN_ARRAY_OFFSET;

--- a/java/fury-core/src/main/java/io/fury/util/Platform.java
+++ b/java/fury-core/src/main/java/io/fury/util/Platform.java
@@ -36,6 +36,7 @@ public final class Platform {
 
   public static final int JAVA_VERSION = _JDKAccess.JAVA_VERSION;
   public static final boolean IS_GRAALVM_IMAGE_BUILD_TIME = _JDKAccess.IS_GRAALVM_IMAGE_BUILD_TIME;
+  public static final boolean IS_GRAALVM_IMAGE_RUN_TIME = _JDKAccess.IS_GRAALVM_IMAGE_RUN_TIME;
   public static final boolean IS_LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
 
   public static final int BOOLEAN_ARRAY_OFFSET;

--- a/java/fury-core/src/main/java/io/fury/util/ReflectionUtils.java
+++ b/java/fury-core/src/main/java/io/fury/util/ReflectionUtils.java
@@ -331,7 +331,7 @@ public class ReflectionUtils {
   }
 
   public static long getFieldOffset(Field field) {
-    if (Platform.IS_GRAALVM_IMAGE_BUILD_TIME) {
+    if (GraalvmSupport.isGraalBuildtime()) {
       // See more details at
       // https://www.graalvm.org/latest/reference-manual/native-image/metadata/Compatibility/#unsafe-memory-access
       throw new IllegalStateException(

--- a/java/fury-core/src/main/java/io/fury/util/unsafe/_JDKAccess.java
+++ b/java/fury-core/src/main/java/io/fury/util/unsafe/_JDKAccess.java
@@ -18,6 +18,7 @@ package io.fury.util.unsafe;
 
 import io.fury.collection.Tuple2;
 import io.fury.type.TypeUtils;
+import io.fury.util.GraalvmSupport;
 import io.fury.util.Preconditions;
 import io.fury.util.Utils;
 import io.fury.util.function.ToByteFunction;
@@ -53,15 +54,9 @@ public class _JDKAccess {
   // CHECKSTYLE.ON:TypeName
   public static final int JAVA_VERSION;
   public static final boolean OPEN_J9;
-  public static final boolean IS_GRAALVM_IMAGE_BUILD_TIME;
-  public static final boolean IS_GRAALVM_IMAGE_RUN_TIME;
   public static final Unsafe UNSAFE;
   public static final Class<?> _INNER_UNSAFE_CLASS;
   public static final Object _INNER_UNSAFE;
-  // https://github.com/oracle/graal/blob/master/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/ImageInfo.java
-  private static final String GRAAL_IMAGE_CODE_KEY = "org.graalvm.nativeimage.imagecode";
-  private static final String GRAAL_IMAGE_BUILDTIME_VALUE = "buildtime";
-  private static final String GRAAL_IMAGE_RUNTIME_VALUE = "runtime";
 
   static {
     String property = System.getProperty("java.specification.version");
@@ -93,10 +88,6 @@ public class _JDKAccess {
       _INNER_UNSAFE_CLASS = null;
       _INNER_UNSAFE = null;
     }
-    IS_GRAALVM_IMAGE_BUILD_TIME =
-        (GRAAL_IMAGE_BUILDTIME_VALUE.equals(System.getProperty(GRAAL_IMAGE_CODE_KEY)));
-    IS_GRAALVM_IMAGE_RUN_TIME =
-        (GRAAL_IMAGE_RUNTIME_VALUE.equals(System.getProperty(GRAAL_IMAGE_CODE_KEY)));
   }
 
   private static final ClassValue<Lookup> lookupCache =
@@ -111,7 +102,7 @@ public class _JDKAccess {
 
   public static Lookup _trustedLookup(Class<?> objectClass) {
     // CHECKSTYLE.ON:MethodName
-    if (IS_GRAALVM_IMAGE_BUILD_TIME) {
+    if (GraalvmSupport.isGraalBuildtime()) {
       // Lookup will init `java.io.FilePermission`,which is not allowed at graalvm build time
       // as a reachable object.
       return _Lookup._trustedLookup(objectClass);

--- a/java/fury-core/src/main/resources/META-INF/native-image/org.furyio/fury-core/native-image.properties
+++ b/java/fury-core/src/main/resources/META-INF/native-image/org.furyio/fury-core/native-image.properties
@@ -15,6 +15,7 @@
 # https://www.graalvm.org/latest/reference-manual/native-image/dynamic-features/Reflection/#unsafe-accesses :
 # The unsafe offset get on build time may be different from runtime
 Args=--initialize-at-build-time=io.fury.memory.MemoryBuffer,\
+    io.fury.util.GraalvmSupport,\
     io.fury.serializer.collection.UnmodifiableSerializers$Offset,\
     io.fury.serializer.collection.SynchronizedSerializers$Offset,\
     io.fury.serializer.collection.CollectionSerializers$ArraysAsListSerializer,\

--- a/java/fury-format/src/main/java/io/fury/format/encoder/RowEncoderBuilder.java
+++ b/java/fury-format/src/main/java/io/fury/format/encoder/RowEncoderBuilder.java
@@ -42,6 +42,7 @@ import io.fury.format.type.DataTypes;
 import io.fury.format.type.TypeInference;
 import io.fury.type.Descriptor;
 import io.fury.type.TypeUtils;
+import io.fury.util.GraalvmSupport;
 import io.fury.util.LoggerFactory;
 import io.fury.util.Platform;
 import io.fury.util.StringUtils;
@@ -225,7 +226,7 @@ public class RowEncoderBuilder extends BaseBinaryEncoderBuilder {
 
   @Override
   protected Expression beanClassExpr() {
-    if (Platform.IS_GRAALVM_IMAGE_BUILD_TIME) {
+    if (GraalvmSupport.isGraalBuildtime()) {
       return staticBeanClassExpr();
     }
     return beanClassRef;

--- a/java/fury-format/src/main/java/io/fury/format/encoder/RowEncoderBuilder.java
+++ b/java/fury-format/src/main/java/io/fury/format/encoder/RowEncoderBuilder.java
@@ -44,7 +44,6 @@ import io.fury.type.Descriptor;
 import io.fury.type.TypeUtils;
 import io.fury.util.GraalvmSupport;
 import io.fury.util.LoggerFactory;
-import io.fury.util.Platform;
 import io.fury.util.StringUtils;
 import java.lang.reflect.Modifier;
 import java.util.SortedMap;


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Support thread safe fury for graalvm native image by cache generated serializer for query by other fury.

Usage example:
```java

import io.fury.Fury;
import io.fury.ThreadLocalFury;
import io.fury.ThreadSafeFury;
import io.fury.util.Preconditions;

import java.util.List;
import java.util.Map;

public class Example {
  static ThreadSafeFury fury;

  static {
    fury = new ThreadLocalFury(classLoader -> {
      Fury f = Fury.builder().requireClassRegistration(true).build();
      // register and generate serializer code.
      f.register(Foo.class, true);
      return f;
    });
  }

  public static void main(String[] args) {
    Preconditions.checkArgument("abc".equals(fury.deserialize(fury.serialize("abc"))));
    Preconditions.checkArgument(List.of(1,2,3).equals(fury.deserialize(fury.serialize(List.of(1,2,3)))));
    Map<String, Integer> map = Map.of("k1", 1, "k2", 2);
    Preconditions.checkArgument(map.equals(fury.deserialize(fury.serialize(map))));
    Foo foo = new Foo(10, "abc", List.of("str1", "str2"), Map.of("k1", 10L, "k2", 20L));
    byte[] bytes = fury.serialize(foo);
    Object o = fury.deserialize(bytes);
    System.out.println(foo);
    System.out.println(o);
    Preconditions.checkArgument(foo.equals(o));
  }
}

```
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #1155
#678  #1115

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
