### PR TITLE
[C++] Split util.h to bit_util.h and time_util.h

### DIFF
--- a/python/pyfury/includes/libutil.pxd
+++ b/python/pyfury/includes/libutil.pxd
@@ -59,7 +59,7 @@ cdef extern from "fury/util/buffer.h" namespace "fury" nogil:
     c_bool AllocateBuffer(uint32_t size, shared_ptr[CBuffer]* out)
 
 
-cdef extern from "fury/util/util.h" namespace "fury::BitUtil" nogil:
+cdef extern from "fury/util/bit_util.h" namespace "fury::util" nogil:
     c_bool GetBit(const uint8_t *bits, uint32_t i)
 
     void SetBit(uint8_t *bits, int64_t i)

--- a/src/fury/row/row.h
+++ b/src/fury/row/row.h
@@ -21,9 +21,9 @@
 #include "arrow/api.h"
 #include "arrow/status.h"
 #include "fury/row/type.h"
+#include "fury/util/bit_util.h"
 #include "fury/util/buffer.h"
 #include "fury/util/status.h"
-#include "fury/util/util.h"
 
 namespace fury {
 
@@ -165,8 +165,8 @@ public:
   int num_fields() const { return num_fields_; }
 
   bool IsNullAt(int i) const override {
-    return BitUtil::GetBit(buffer_->data() + base_offset_,
-                           static_cast<uint32_t>(i));
+    return util::GetBit(buffer_->data() + base_offset_,
+                        static_cast<uint32_t>(i));
   }
 
   int GetOffset(int i) const override {
@@ -189,11 +189,11 @@ public:
   }
 
   void SetNullAt(int i) override {
-    BitUtil::SetBit(buffer()->data() + base_offset_, i);
+    util::SetBit(buffer()->data() + base_offset_, i);
   }
 
   void SetNotNullAt(int i) override {
-    BitUtil::ClearBit(buffer()->data() + base_offset_, i);
+    util::ClearBit(buffer()->data() + base_offset_, i);
   }
 
   std::string ToString() const override;
@@ -237,8 +237,8 @@ public:
   int num_elements() const { return num_elements_; }
 
   bool IsNullAt(int i) const override {
-    return BitUtil::GetBit(buffer_->data() + base_offset_ + 8,
-                           static_cast<uint32_t>(i));
+    return util::GetBit(buffer_->data() + base_offset_ + 8,
+                        static_cast<uint32_t>(i));
   }
 
   int GetOffset(int i) const override {
@@ -261,13 +261,13 @@ public:
   }
 
   void SetNullAt(int i) override {
-    BitUtil::SetBit(buffer_->data() + base_offset_ + 8, i);
+    util::SetBit(buffer_->data() + base_offset_ + 8, i);
     // we assume the corresponding column was already 0
     // or will be set to 0 later by the caller side
   }
 
   void SetNotNullAt(int i) override {
-    BitUtil::ClearBit(buffer_->data() + base_offset_ + 8, i);
+    util::ClearBit(buffer_->data() + base_offset_ + 8, i);
   }
 
   std::string ToString() const override;

--- a/src/fury/row/writer.cc
+++ b/src/fury/row/writer.cc
@@ -43,9 +43,8 @@ void Writer::ZeroOutPaddingBytes(uint32_t num_bytes) {
 }
 
 bool Writer::IsNullAt(int i) const {
-  return BitUtil::GetBit(buffer_->data() + starting_offset_ +
-                             bytes_before_bitmap_,
-                         static_cast<uint32_t>(i));
+  return util::GetBit(buffer_->data() + starting_offset_ + bytes_before_bitmap_,
+                      static_cast<uint32_t>(i));
 }
 
 void Writer::WriteString(int i, std::string_view value) {
@@ -59,7 +58,7 @@ void Writer::WriteBytes(int i, const uint8_t *input, uint32_t length) {
 
 void Writer::WriteUnaligned(int i, const uint8_t *input, uint32_t offset,
                             uint32_t num_bytes) {
-  int round_size = BitUtil::RoundNumberOfBytesToNearestWord(num_bytes);
+  int round_size = util::RoundNumberOfBytesToNearestWord(num_bytes);
   buffer_->Grow(round_size);
   ZeroOutPaddingBytes(num_bytes);
   buffer_->UnsafePut(cursor(), input + offset, num_bytes);
@@ -206,7 +205,7 @@ void ArrayWriter::Reset(uint32_t num_elements) {
   uint64_t data_size = num_elements_ * (uint64_t)element_size_;
   FURY_CHECK(data_size < std::numeric_limits<int>::max());
   int fixed_part_bytes =
-      BitUtil::RoundNumberOfBytesToNearestWord(static_cast<int>(data_size));
+      util::RoundNumberOfBytesToNearestWord(static_cast<int>(data_size));
   assert((fixed_part_bytes >= data_size) && "too much elements");
   buffer_->Grow(header_in_bytes_ + fixed_part_bytes);
 

--- a/src/fury/row/writer.h
+++ b/src/fury/row/writer.h
@@ -22,9 +22,9 @@
 #include <vector>
 
 #include "fury/row/row.h"
+#include "fury/util/bit_util.h"
 #include "fury/util/buffer.h"
 #include "fury/util/logging.h"
-#include "fury/util/util.h"
 
 namespace fury {
 
@@ -59,13 +59,12 @@ public:
   void ZeroOutPaddingBytes(uint32_t num_bytes);
 
   void SetNullAt(int i) {
-    BitUtil::SetBit(buffer_->data() + starting_offset_ + bytes_before_bitmap_,
-                    i);
+    util::SetBit(buffer_->data() + starting_offset_ + bytes_before_bitmap_, i);
   }
 
   void SetNotNullAt(int i) {
-    BitUtil::ClearBit(buffer_->data() + starting_offset_ + bytes_before_bitmap_,
-                      i);
+    util::ClearBit(buffer_->data() + starting_offset_ + bytes_before_bitmap_,
+                   i);
   }
 
   bool IsNullAt(int i) const;

--- a/src/fury/util/BUILD
+++ b/src/fury/util/BUILD
@@ -4,8 +4,8 @@ load("//bazel:fury.bzl", "COPTS")
 
 cc_library(
     name = "fury_util",
-    srcs = ["status.cc", "buffer.cc", "logging.cc", "util.cc"],
-    hdrs = ["status.h", "buffer.h", "logging.h", "util.h"],
+    srcs = glob(["*.cc"], exclude=["*test.cc"]),
+    hdrs = glob(["*.h"]),
     strip_include_prefix = "/src",
     copts = COPTS,
     alwayslink=True,
@@ -21,8 +21,8 @@ cc_library(
 
 
 cc_test(
-    name = "util_test",
-    srcs = ["util_test.cc"],
+    name = "time_util_test",
+    srcs = ["time_util_test.cc"],
     copts = COPTS,
     deps = [
         ":fury_util",

--- a/src/fury/util/bit_util.h
+++ b/src/fury/util/bit_util.h
@@ -67,7 +67,7 @@
 
 namespace fury {
 
-namespace BitUtil {
+namespace util {
 
 //
 // Byte-swap 16-bit, 32-bit and 64-bit values. based on arrow/util/bit-util.h
@@ -218,8 +218,7 @@ static inline std::string hex(uint8_t *data, int32_t length) {
   }
   return result;
 }
-} // namespace BitUtil
 
-std::string FormatTimePoint(std::chrono::system_clock::time_point tp);
+} // namespace util
 
 } // namespace fury

--- a/src/fury/util/buffer.cc
+++ b/src/fury/util/buffer.cc
@@ -110,7 +110,7 @@ std::string Buffer::ToString() const {
 }
 
 std::string Buffer::Hex() const {
-  return BitUtil::hex(data(), static_cast<int32_t>(size_));
+  return util::hex(data(), static_cast<int32_t>(size_));
 }
 
 bool AllocateBuffer(uint32_t size, std::shared_ptr<Buffer> *out) {

--- a/src/fury/util/buffer.h
+++ b/src/fury/util/buffer.h
@@ -22,8 +22,8 @@
 #include <memory>
 #include <string>
 
+#include "fury/util/bit_util.h"
 #include "fury/util/logging.h"
-#include "fury/util/util.h"
 
 namespace fury {
 
@@ -201,7 +201,7 @@ public:
       // see
       // https://github.com/facebook/folly/blob/master/folly/docs/FBVector.md
       // for discussion.
-      auto new_size = BitUtil::RoundNumberOfBytesToNearestWord(len * 2);
+      auto new_size = util::RoundNumberOfBytesToNearestWord(len * 2);
       Reserve(new_size);
     }
   }

--- a/src/fury/util/logging.cc
+++ b/src/fury/util/logging.cc
@@ -18,7 +18,7 @@
 #include "absl/debugging/failure_signal_handler.h"
 #include "absl/debugging/stacktrace.h"
 #include "absl/debugging/symbolize.h"
-#include "fury/util/util.h"
+#include "fury/util/time_util.h"
 #include <unordered_map>
 #include <vector>
 

--- a/src/fury/util/time_util.cc
+++ b/src/fury/util/time_util.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "fury/util/time_util.h"
 #include <chrono>
 #include <ctime>
 #include <iomanip>
@@ -23,6 +24,7 @@
 namespace fury {
 
 using std::chrono::system_clock;
+
 std::string FormatTimePoint(system_clock::time_point tp) {
   std::stringstream ss;
   time_t raw_time = system_clock::to_time_t(tp);

--- a/src/fury/util/time_util.h
+++ b/src/fury/util/time_util.h
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include <chrono>

--- a/src/fury/util/time_util.h
+++ b/src/fury/util/time_util.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <chrono>
+#include <string>
+
+namespace fury {
+
+std::string FormatTimePoint(std::chrono::system_clock::time_point tp);
+
+}

--- a/src/fury/util/time_util_test.cc
+++ b/src/fury/util/time_util_test.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "fury/util/util.h"
+#include "fury/util/time_util.h"
 #include "gtest/gtest.h"
 
 namespace fury {


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

`util/util.h` is splitted to `util/bit_util.h` and `util/time_util.h`.
namespace `BitUtil` is renamed to `util`.


## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
