### PR TITLE
[C++] Support cv-qualified types in row encoder

### DIFF
--- a/src/fury/encoder/row_encoder_test.cc
+++ b/src/fury/encoder/row_encoder_test.cc
@@ -76,6 +76,27 @@ TEST(RowEncoder, String) {
   ASSERT_EQ(row->GetInt32(0), 233);
 }
 
+struct C {
+  const int a;
+  volatile float b;
+  bool c;
+};
+
+FURY_FIELD_INFO(C, a, b, c);
+
+TEST(RowEncoder, Const) {
+  RowWriter writer(encoder::RowEncodeTrait<C>::Schema());
+  writer.Reset();
+
+  C c{233, 1.1, true};
+  encoder::RowEncodeTrait<C>::Write(c, writer);
+
+  auto row = writer.ToRow();
+  ASSERT_EQ(row->GetInt32(0), 233);
+  ASSERT_FLOAT_EQ(row->GetFloat(1), 1.1);
+  ASSERT_EQ(row->GetBoolean(2), true);
+}
+
 } // namespace test
 
 } // namespace fury


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Now we can add cv qualifiers to field types ,e.g.
```c++
struct A {
  const int x;
  volatile float y;
}

FURY_FIELD_INFO(A, x, y);

...
```

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
