### PR TITLE
[C++] Remove useless fields and macro in logging

### DIFF
--- a/src/fury/util/logging.cc
+++ b/src/fury/util/logging.cc
@@ -47,15 +47,15 @@ std::string GetCallTrace() {
   return output;
 }
 
-std::string LogLevelAsString(FuryLogLevel level) {
-  static std::unordered_map<FuryLogLevel, std::string> level_to_str = {
-      {FuryLogLevel::DEBUG, "DEBUG"},     {FuryLogLevel::INFO, "INFO"},
-      {FuryLogLevel::WARNING, "WARNING"}, {FuryLogLevel::ERROR, "ERROR"},
-      {FuryLogLevel::FATAL, "FATAL"},
-  };
+std::unordered_map<FuryLogLevel, std::string> log_level_to_str = {
+    {FuryLogLevel::DEBUG, "DEBUG"},     {FuryLogLevel::INFO, "INFO"},
+    {FuryLogLevel::WARNING, "WARNING"}, {FuryLogLevel::ERROR, "ERROR"},
+    {FuryLogLevel::FATAL, "FATAL"},
+};
 
-  auto it = level_to_str.find(level);
-  if (it == level_to_str.end()) {
+std::string LogLevelAsString(FuryLogLevel level) {
+  auto it = log_level_to_str.find(level);
+  if (it == log_level_to_str.end()) {
     return "UNKNOWN";
   }
   return it->second;

--- a/src/fury/util/logging.cc
+++ b/src/fury/util/logging.cc
@@ -24,11 +24,13 @@
 
 namespace std {
 template <> struct hash<fury::FuryLogLevel> {
-  size_t operator()(const fury::FuryLogLevel &t) const { return size_t(t); }
+  size_t operator()(fury::FuryLogLevel t) const { return size_t(t); }
 };
 } // namespace std
 
 namespace fury {
+
+const FuryLogLevel fury_severity_threshold = FuryLog::GetLogLevel();
 
 std::string GetCallTrace() {
   std::vector<void *> local_stack;
@@ -76,9 +78,10 @@ FuryLogLevel FuryLog::GetLogLevel() {
     } else if (data == "fatal") {
       severity_threshold = FuryLogLevel::FATAL;
     } else {
-      FURY_LOG(WARNING) << "Unrecognized setting of FuryLogLevel=" << var_value;
+      FURY_LOG_INTERNAL(WARNING)
+          << "Unrecognized setting of FuryLogLevel=" << var_value;
     }
-    FURY_LOG(INFO)
+    FURY_LOG_INTERNAL(INFO)
         << "Set ray log level from environment variable RAY_BACKEND_LOG_LEVEL"
         << " to " << static_cast<int>(severity_threshold);
   }
@@ -86,8 +89,7 @@ FuryLogLevel FuryLog::GetLogLevel() {
 }
 
 FuryLog::FuryLog(const char *file_name, int line_number, FuryLogLevel severity)
-    : is_enabled_(severity >= __fury_severity_threshold__),
-      severity_(severity) {
+    : severity_(severity) {
   Stream() << "[" << FormatTimePoint(std::chrono::system_clock::now()) << "] "
            << LogLevelAsString(severity) << " " << file_name << ":"
            << line_number << ": ";
@@ -102,10 +104,8 @@ FuryLog::~FuryLog() {
   Stream() << "\n" << std::endl;
 }
 
-bool FuryLog::IsEnabled() const { return is_enabled_; }
-
 bool FuryLog::IsLevelEnabled(FuryLogLevel log_level) {
-  return log_level >= __fury_severity_threshold__;
+  return log_level >= fury_severity_threshold;
 }
 
 } // namespace fury

--- a/src/fury/util/status.h
+++ b/src/fury/util/status.h
@@ -46,8 +46,6 @@
 
 namespace fury {
 
-#define FURY_IGNORE_EXPR(expr) ((void)(expr))
-
 // Return the given status if it is not OK.
 #define FURY_RETURN_NOT_OK(s)                                                  \
   do {                                                                         \


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- refactor some macros
- move `fury_severity_threshold` to `.cc`
- remove static local variables since it will bring locks
- remove `is_enabled_` field
- we cannot use `FURY_LOG` inside GetLogLevel since `fury_severity_threshold` has not yet been initialized

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
