### PR TITLE
[C++] Add RowEncoder wrapper to RowEncodeTrait

### DIFF
--- a/src/fury/encoder/BUILD
+++ b/src/fury/encoder/BUILD
@@ -17,7 +17,7 @@ cc_library(
 
 cc_test(
     name = "row_encoder_test",
-    srcs = ["row_encoder_test.cc"],
+    srcs = glob(["*_test.cc"]),
     copts = COPTS,
     deps = [
         ":fury_encoder",

--- a/src/fury/encoder/row_encode_trait.h
+++ b/src/fury/encoder/row_encode_trait.h
@@ -18,12 +18,9 @@
 
 #include "fury/meta/field_info.h"
 #include "fury/meta/type_traits.h"
-#include "fury/row/row.h"
-#include "src/fury/row/writer.h"
+#include "fury/row/writer.h"
 #include <string_view>
-#include <type_traits>
 #include <utility>
-#include <variant>
 
 namespace fury {
 
@@ -82,6 +79,8 @@ struct EmptyWriteVisitor {
 
 template <typename C> struct DefaultWriteVisitor {
   C &cont;
+
+  DefaultWriteVisitor(C &cont) : cont(cont) {}
 
   template <typename> void Visit(std::unique_ptr<RowWriter> writer) {
     cont.push_back(std::move(writer));

--- a/src/fury/encoder/row_encode_trait_test.cc
+++ b/src/fury/encoder/row_encode_trait_test.cc
@@ -17,7 +17,7 @@
 #include "gtest/gtest.h"
 #include <type_traits>
 
-#include "fury/encoder/row_encoder.h"
+#include "fury/encoder/row_encode_trait.h"
 #include "src/fury/row/writer.h"
 
 namespace fury {
@@ -32,7 +32,7 @@ struct A {
 
 FURY_FIELD_INFO(A, x, y, z);
 
-TEST(RowEncoder, Simple) {
+TEST(RowEncodeTrait, Basic) {
   auto field_vector = encoder::RowEncodeTrait<A>::FieldVector();
 
   static_assert(std::is_same_v<decltype(field_vector), arrow::FieldVector>);
@@ -65,7 +65,7 @@ struct B {
 
 FURY_FIELD_INFO(B, num, str);
 
-TEST(RowEncoder, String) {
+TEST(RowEncodeTrait, String) {
   RowWriter writer(encoder::RowEncodeTrait<B>::Schema());
   writer.Reset();
 
@@ -87,7 +87,7 @@ struct C {
 
 FURY_FIELD_INFO(C, a, b, c);
 
-TEST(RowEncoder, Const) {
+TEST(RowEncodeTrait, Const) {
   RowWriter writer(encoder::RowEncodeTrait<C>::Schema());
   writer.Reset();
 
@@ -108,7 +108,7 @@ struct D {
 
 FURY_FIELD_INFO(D, x, y, z);
 
-TEST(RowEncoder, NestedStruct) {
+TEST(RowEncodeTrait, NestedStruct) {
   RowWriter writer(encoder::RowEncodeTrait<D>::Schema());
   std::vector<std::unique_ptr<RowWriter>> children;
   writer.Reset();

--- a/src/fury/encoder/row_encoder.h
+++ b/src/fury/encoder/row_encoder.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "fury/encoder/row_encode_trait.h"
+#include <memory>
+#include <type_traits>
+
+namespace fury {
+
+namespace encoder {
+
+template <typename T> struct RowEncoder {
+  static_assert(std::is_class_v<T>, "currently only class types are supported");
+
+  RowEncoder()
+      : writer_(std::make_unique<RowWriter>(RowEncodeTrait<T>::Schema())) {
+    writer_->Reset();
+  }
+
+  void Encode(const T &value) {
+    RowEncodeTrait<T>::Write(DefaultWriteVisitor{children_}, value,
+                             GetWriter());
+  }
+
+  RowWriter &GetWriter() const { return *writer_.get(); }
+  const std::vector<std::unique_ptr<RowWriter>> &GetChildren() const {
+    return children_;
+  }
+  const arrow::Schema &GetSchema() const { return *writer_->schema().get(); }
+
+  void ResetChildren() { children_.clear(); }
+
+private:
+  std::unique_ptr<RowWriter> writer_;
+  std::vector<std::unique_ptr<RowWriter>> children_;
+};
+
+} // namespace encoder
+
+} // namespace fury

--- a/src/fury/encoder/row_encoder_test.cc
+++ b/src/fury/encoder/row_encoder_test.cc
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+#include <type_traits>
+
+#include "fury/encoder/row_encode_trait.h"
+#include "src/fury/encoder/row_encoder.h"
+#include "src/fury/row/writer.h"
+
+namespace fury {
+
+namespace test2 {
+
+struct A {
+  float a;
+  std::string b;
+};
+
+FURY_FIELD_INFO(A, a, b);
+
+struct B {
+  int x;
+  A y;
+};
+
+FURY_FIELD_INFO(B, x, y);
+
+TEST(RowEncoder, Simple) {
+  B v{233, {1.23, "hello"}};
+
+  encoder::RowEncoder<B> enc;
+
+  auto &schema = enc.GetSchema();
+  ASSERT_EQ(schema.field_names(), (std::vector<std::string>{"x", "y"}));
+  ASSERT_EQ(schema.field(0)->type()->name(), "int32");
+  ASSERT_EQ(schema.field(1)->type()->name(), "struct");
+  ASSERT_EQ(schema.field(1)->type()->field(0)->name(), "a");
+  ASSERT_EQ(schema.field(1)->type()->field(1)->name(), "b");
+  ASSERT_EQ(schema.field(1)->type()->field(0)->type()->name(), "float");
+  ASSERT_EQ(schema.field(1)->type()->field(1)->type()->name(), "utf8");
+
+  enc.Encode(v);
+
+  auto row = enc.GetWriter().ToRow();
+  ASSERT_EQ(row->GetInt32(0), 233);
+  auto y_row = row->GetStruct(1);
+  ASSERT_EQ(y_row->GetString(1), "hello");
+  ASSERT_FLOAT_EQ(y_row->GetFloat(0), 1.23);
+}
+
+} // namespace test2
+} // namespace fury

--- a/src/fury/util/buffer.cc
+++ b/src/fury/util/buffer.cc
@@ -58,7 +58,7 @@ Buffer &Buffer::operator=(Buffer &&buffer) noexcept {
 
 Buffer::~Buffer() {
   if (own_data_) {
-    delete data_;
+    free(data_);
     data_ = nullptr;
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

We added a simpler interface to use `RowEncodeTrait` named `RowEncoder`, and renamed `row_encoder.h` to `row_encode_trait.h`

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
