### PR TITLE
[C++] update bazel version from 4.2 to 6.3.2

### DIFF
--- a/docs/guide/DEVELOPMENT.md
+++ b/docs/guide/DEVELOPMENT.md
@@ -52,7 +52,7 @@ bazel build //src/fury/row:fury_row_format
 #### Environment Requirements
 
 - cpp 11+
-- bazel 4.2
+- bazel 6.3.2
 
 ### Building Fury GoLang
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
We update bazel version to 6.3.2 in #1064  but didn't update the doc. This PR update bazel version from 4.2 to 6.3.2
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#1064 
## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
