### PR TITLE
[Rust] Support row map

### DIFF
--- a/rust/fury/src/deserializer.rs
+++ b/rust/fury/src/deserializer.rs
@@ -12,18 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::buffer::Reader;
+use super::types::Language;
 use crate::{
     error::Error,
     types::{FuryMeta, RefFlag},
-    Language,
 };
 use chrono::{DateTime, Days, NaiveDate, NaiveDateTime, TimeZone, Utc};
 use std::{
     collections::{HashMap, HashSet},
     mem,
 };
-
-use super::buffer::Reader;
 
 fn from_u8_slice<T: Clone>(slice: &[u8]) -> Vec<T> {
     let byte_len = slice.len() / mem::size_of::<T>();

--- a/rust/fury/src/error.rs
+++ b/rust/fury/src/error.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{FieldType, Language};
+use super::types::{FieldType, Language};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/rust/fury/src/lib.rs
+++ b/rust/fury/src/lib.rs
@@ -12,21 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod buffer;
 mod deserializer;
 mod error;
+mod row;
 mod serializer;
 mod types;
 
-pub mod buffer;
 pub use deserializer::from_buffer;
-pub use deserializer::Deserialize;
-pub use deserializer::DeserializerState;
 pub use error::Error;
+pub use fury_derive::*;
+pub use row::{from_row, to_row};
 pub use serializer::to_buffer;
-pub use serializer::Serialize;
-pub use serializer::SerializerState;
-pub use types::{
-    compute_field_hash, compute_string_hash, compute_struct_hash, config_flags, FieldType,
-    FuryMeta, Language, RefFlag, SIZE_OF_REF_AND_TYPE,
-};
-pub mod row;
+
+pub mod __derive {
+    pub use crate::buffer::{Reader, Writer};
+    pub use crate::deserializer::{Deserialize, DeserializerState};
+    pub use crate::row::{Row, RowViewer, RowWriter, StructViewer, StructWriter};
+    pub use crate::serializer::{Serialize, SerializerState};
+    pub use crate::types::{compute_struct_hash, FieldType, FuryMeta, SIZE_OF_REF_AND_TYPE};
+    pub use crate::Error;
+}

--- a/rust/fury/src/row/reader.rs
+++ b/rust/fury/src/row/reader.rs
@@ -94,6 +94,50 @@ impl<'r> RowViewer<'r> for ArrayViewer<'r> {
     }
 }
 
+#[derive(Clone, Copy)]
+pub struct MapViewer<'r> {
+    key_row: &'r [u8],
+    value_row: &'r [u8],
+    row: &'r [u8],
+}
+
+impl<'r> MapViewer<'r> {
+    pub fn new(row: &'r [u8]) -> MapViewer<'r> {
+        let key_byte_size = LittleEndian::read_u64(&row[0..8]) as usize;
+        MapViewer {
+            row,
+            value_row: &row[key_byte_size + 8..row.len()],
+            key_row: &row[8..key_byte_size + 8],
+        }
+    }
+
+    pub fn get_key_row(&self) -> &[u8] {
+        self.key_row
+    }
+
+    pub fn get_value_row(&self) -> &[u8] {
+        self.value_row
+    }
+}
+
+impl<'r> RowViewer<'r> for MapViewer<'r> {
+    fn get_offset_size(&self, _idx: usize) -> (u32, u32) {
+        panic!("unreachable code")
+    }
+
+    fn get_field_bytes(&self, _idx: usize) -> &'r [u8] {
+        panic!("unreachable code")
+    }
+
+    fn get_field_offset(&self, _idx: usize) -> usize {
+        panic!("unreachable code")
+    }
+
+    fn row(&self) -> &'r [u8] {
+        self.row
+    }
+}
+
 pub fn from_row<'a, T: Row<'a>>(row: &'a [u8]) -> T::ReadResult {
     T::cast(row)
 }

--- a/rust/fury/src/serializer.rs
+++ b/rust/fury/src/serializer.rs
@@ -31,7 +31,7 @@
 //! fury_derive would expand the code and automatic implements the Serialize trait
 
 use super::buffer::Writer;
-use crate::{config_flags, FuryMeta, Language, RefFlag, SIZE_OF_REF_AND_TYPE};
+use super::types::{config_flags, FuryMeta, Language, RefFlag, SIZE_OF_REF_AND_TYPE};
 use chrono::{NaiveDate, NaiveDateTime};
 use std::collections::{HashMap, HashSet};
 use std::mem;

--- a/rust/tests/tests/test_row.rs
+++ b/rust/tests/tests/test_row.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use fury::row::{from_row, to_row};
-use fury_derive::FuryRow;
+use std::collections::BTreeMap;
+
+use fury::{from_row, to_row, FuryRow};
 
 #[test]
 fn row() {
@@ -23,6 +24,7 @@ fn row() {
         f2: i8,
         f3: Vec<u8>,
         f4: Vec<i8>,
+        f5: BTreeMap<String, String>,
     }
 
     #[derive(FuryRow)]
@@ -30,25 +32,42 @@ fn row() {
         f3: Foo,
     }
 
+    let mut f5: BTreeMap<String, String> = BTreeMap::new();
+    f5.insert(String::from("k1"), String::from("v1"));
+    f5.insert(String::from("k2"), String::from("v2"));
+
     let row = to_row(&Bar {
         f3: Foo {
             f1: String::from("hello"),
             f2: 1,
             f3: vec![1, 2, 3],
             f4: vec![-1, 2, -3],
+            f5,
         },
     });
 
     let obj = from_row::<Bar>(&row);
-    let f1: &str = obj.get_f3().get_f1();
+    let f1: &str = obj.f3().f1();
     assert_eq!(f1, "hello");
-    let f2: i8 = obj.get_f3().get_f2();
+    let f2: i8 = obj.f3().f2();
     assert_eq!(f2, 1);
-    let f3: &[u8] = obj.get_f3().get_f3();
+    let f3: &[u8] = obj.f3().f3();
     assert_eq!(f3, vec![1, 2, 3]);
-    let f4_size: usize = obj.get_f3().get_f4().size();
+    let f4_size: usize = obj.f3().f4().size();
     assert_eq!(f4_size, 3);
-    assert_eq!(obj.get_f3().get_f4().get(0), -1);
-    assert_eq!(obj.get_f3().get_f4().get(1), 2);
-    assert_eq!(obj.get_f3().get_f4().get(2), -3);
+    assert_eq!(obj.f3().f4().get(0), -1);
+    assert_eq!(obj.f3().f4().get(1), 2);
+    assert_eq!(obj.f3().f4().get(2), -3);
+
+    let binding = obj.f3().f5();
+
+    assert_eq!(binding.keys().size(), 2);
+    assert_eq!(binding.keys().get(0), "k1");
+
+    assert_eq!(binding.values().size(), 2);
+    assert_eq!(binding.values().get(0), "v1");
+
+    let f5 = binding.to_btree_map().expect("should be map");
+    assert_eq!(f5.get("k1").expect("should exists"), &"v1");
+    assert_eq!(f5.get("k2").expect("should exists"), &"v2");
 }


### PR DESCRIPTION
## What do these changes do?
1. Ensure that the library only exports the necessary modules.
2. Rust row format support Map.
  Add a new binary accessor named MapGetter, which wraps two ArrayGetter instances to access keys and values. Additionally, include a function to convert keys and values into a BTreeMap.
  
  usage:
  ```rust
  #[test]
  fn rowmap() {
      #[derive(FuryRow)]
      struct Foo {
          f5: BTreeMap<String, String>,
      }
  
      let mut f5: BTreeMap<String, String> = BTreeMap::new();
      f5.insert(String::from("k1"), String::from("v1"));
      f5.insert(String::from("k2"), String::from("v2"));
  
      let row = to_row(&Foo {
          f5,
      },);
  
      let obj = from_row::<Foo>(&row);
      let binding = obj.f5();
  
      assert_eq!(binding.keys().size(), 2);
      assert_eq!(binding.keys().get(0), "k1");
  
      assert_eq!(binding.values().size(), 2);
      assert_eq!(binding.values().get(0), "v1");
  
      let f5 = binding.to_btree_map().expect("should be map");
      assert_eq!(f5.get("k1").expect("should exists"), &"v1");
      assert_eq!(f5.get("k2").expect("should exists"), &"v2");
  }
  ```

## Related issue number
Closes #1205 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
