### PR TITLE
[JavaScript] Support partial record

### DIFF
--- a/javascript/packages/fury/lib/description.ts
+++ b/javascript/packages/fury/lib/description.ts
@@ -59,7 +59,7 @@ type Props<T> = T extends {
     };
 }
     ? {
-        [P in keyof T2]: (ToRecordType<T2[P]> | null);
+        [P in keyof T2]?: (ToRecordType<T2[P]> | null);
     }
     : unknown;
 

--- a/javascript/packages/fury/lib/internalSerializer/bool.ts
+++ b/javascript/packages/fury/lib/internalSerializer/bool.ts
@@ -26,7 +26,7 @@ export default (fury: Fury) => {
         ...referenceResolver.deref(() => {
             return readUInt8() === 0 ? false : true
         }),
-        write: referenceResolver.withNotNullableWriter(InternalSerializerType.BOOL, (v: boolean) => {
+        write: referenceResolver.withNotNullableWriter(InternalSerializerType.BOOL, false, (v: boolean) => {
             writeUInt8(v ? 1 : 0)
         }),
         writeWithoutType: (v: boolean) => {

--- a/javascript/packages/fury/lib/internalSerializer/datetime.ts
+++ b/javascript/packages/fury/lib/internalSerializer/datetime.ts
@@ -17,7 +17,8 @@
 import  {Fury} from "../type";
 import { InternalSerializerType } from "../type";
 
-const epoch =  new Date('1970/01/01 00:00').getTime();
+const epochDate =  new Date('1970/01/01 00:00');
+const epoch = epochDate.getTime();
 
 export const timestampSerializer = (fury: Fury) => {
     const { binaryReader, binaryWriter, referenceResolver} = fury;
@@ -28,7 +29,7 @@ export const timestampSerializer = (fury: Fury) => {
         ...referenceResolver.deref(() => {
             return new Date(Number(readInt64()));
         }),
-        write: referenceResolver.withNotNullableWriter(InternalSerializerType.TIMESTAMP, (v: Date) => {
+        write: referenceResolver.withNotNullableWriter(InternalSerializerType.TIMESTAMP, epochDate, (v: Date) => {
             writeInt64(BigInt(v.getTime()));
         }),
         config: () => {
@@ -48,7 +49,7 @@ export const dateSerializer = (fury: Fury) => {
             const day = readInt32();
             return new Date(epoch + (day * (24*60*60) * 1000));
         }),
-        write: referenceResolver.withNotNullableWriter(InternalSerializerType.DATE, (v: Date) => {
+        write: referenceResolver.withNotNullableWriter(InternalSerializerType.DATE, epochDate, (v: Date) => {
             const diff = v.getTime() - epoch;
             const day = Math.floor(diff / 1000 / (24*60*60))
             writeInt32(day);

--- a/javascript/packages/fury/lib/internalSerializer/number.ts
+++ b/javascript/packages/fury/lib/internalSerializer/number.ts
@@ -24,7 +24,7 @@ export const uInt8Serializer = (fury: Fury) => {
         ...referenceResolver.deref(() => {
             return readUInt8();
         }),
-        write: referenceResolver.withNotNullableWriter(InternalSerializerType.UINT8, (v: number) => {
+        write: referenceResolver.withNotNullableWriter(InternalSerializerType.UINT8, 0, (v: number) => {
             writeUInt8(v);
         }),
         config: () => {
@@ -44,7 +44,7 @@ export const floatSerializer = (fury: Fury) => {
         ...referenceResolver.deref(() => {
             return readFloat();
         }),
-        write: referenceResolver.withNotNullableWriter(InternalSerializerType.FLOAT, (v: number) => {
+        write: referenceResolver.withNotNullableWriter(InternalSerializerType.FLOAT, 0, (v: number) => {
             writeFloat(v);
         }),
         writeWithoutType: (v: number) => {
@@ -68,7 +68,7 @@ export const doubleSerializer = (fury: Fury) => {
         ...referenceResolver.deref(() => {
             return readDouble();
         }),
-        write: referenceResolver.withNotNullableWriter(InternalSerializerType.DOUBLE, (v: number) => {
+        write: referenceResolver.withNotNullableWriter(InternalSerializerType.DOUBLE, 0, (v: number) => {
             writeDouble(v);
         }),
         writeWithoutType: (v: number) => {
@@ -91,7 +91,7 @@ export const int8Serializer = (fury: Fury) => {
         ...referenceResolver.deref(() => {
             return readInt8();
         }),
-        write: referenceResolver.withNotNullableWriter(InternalSerializerType.INT8, (v: number) => {
+        write: referenceResolver.withNotNullableWriter(InternalSerializerType.INT8, 0, (v: number) => {
             writeInt8(v);
         }),
         config: () => {
@@ -111,7 +111,7 @@ export const uInt16Serializer = (fury: Fury) => {
         ...referenceResolver.deref(() => {
             return readUInt16();
         }),
-        write: referenceResolver.withNotNullableWriter(InternalSerializerType.UINT16, (v: number) => {
+        write: referenceResolver.withNotNullableWriter(InternalSerializerType.UINT16, 0, (v: number) => {
             writeUInt16(v);
         }),
         config: () => {
@@ -131,7 +131,7 @@ export const int16Serializer = (fury: Fury) => {
         ...referenceResolver.deref(() => {
             return readInt16();
         }),
-        write: referenceResolver.withNotNullableWriter(InternalSerializerType.INT16, (v: number) => {
+        write: referenceResolver.withNotNullableWriter(InternalSerializerType.INT16, 0, (v: number) => {
             writeInt16(v);
         }),
         writeWithoutType: (v: number) => {
@@ -155,7 +155,7 @@ export const uInt32Serializer = (fury: Fury) => {
         ...referenceResolver.deref(() => {
             return readUInt32();
         }),
-        write: referenceResolver.withNotNullableWriter(InternalSerializerType.UINT32, (v: number) => {
+        write: referenceResolver.withNotNullableWriter(InternalSerializerType.UINT32, 0, (v: number) => {
             writeUInt32(v);
         }),
         config: () => {
@@ -175,7 +175,7 @@ export const int32Serializer = (fury: Fury) => {
         ...referenceResolver.deref(() => {
             return readInt32();
         }),
-        write: referenceResolver.withNotNullableWriter(InternalSerializerType.INT32, (v: number) => {
+        write: referenceResolver.withNotNullableWriter(InternalSerializerType.INT32, 0, (v: number) => {
             writeInt32(v);
         }),
         writeWithoutType: (v: number) => {
@@ -199,7 +199,7 @@ export const uInt64Serializer = (fury: Fury) => {
         ...referenceResolver.deref(() => {
             return readUInt64();
         }),
-        write: referenceResolver.withNotNullableWriter(InternalSerializerType.UINT64, (v: bigint) => {
+        write: referenceResolver.withNotNullableWriter(InternalSerializerType.UINT64, BigInt(0), (v: bigint) => {
             writeUInt64(v);
         }),
         config: () => {
@@ -219,7 +219,7 @@ export const int64Serializer = (fury: Fury) => {
         ...referenceResolver.deref(() => {
             return readInt64();
         }),
-        write: referenceResolver.withNotNullableWriter(InternalSerializerType.INT64, (v: bigint) => {
+        write: referenceResolver.withNotNullableWriter(InternalSerializerType.INT64, BigInt(0), (v: bigint) => {
             writeInt64(v);
         }),
         writeWithoutType: (v: bigint) => {

--- a/javascript/packages/fury/lib/internalSerializer/string.ts
+++ b/javascript/packages/fury/lib/internalSerializer/string.ts
@@ -35,7 +35,7 @@ export default (fury: Fury) => {
             const result = readStringUtf8(len);
             return result;
         }),
-        write: referenceResolver.withNotNullableWriter(InternalSerializerType.STRING, (v: string) => {
+        write: referenceResolver.withNotNullableWriter(InternalSerializerType.STRING, "", (v: string) => {
             writeStringOfVarInt32(v);
         }),
         writeWithoutType: (v: string) => {

--- a/javascript/packages/fury/lib/referenceResolver.ts
+++ b/javascript/packages/fury/lib/referenceResolver.ts
@@ -84,7 +84,7 @@ export const ReferenceResolver = (
     const head = makeHead(RefFlags.RefValueFlag, type);
     if (config.refTracking) {
       return (v: T) => {
-        if (v !== null) {
+        if (v !== null && v !== undefined) {
           const existsId = existsWriteObject(v);
           if (typeof existsId === "number") {
             binaryWriter.int8(RefFlags.RefFlag);
@@ -100,7 +100,7 @@ export const ReferenceResolver = (
       };
     } else {
       return (v: T) => {
-        if (v !== null) {
+        if (v !== null && v !== undefined) {
           int24(head);
           fn(v);
         } else {
@@ -112,13 +112,18 @@ export const ReferenceResolver = (
 
   function withNotNullableWriter<T>(
     type: InternalSerializerType,
+    defaultValue: T,
     fn: SerializerWrite<T>
   ) {
     const head = makeHead(RefFlags.NotNullValueFlag, type);
     const int24 = binaryWriter.int24;
     return (v: T) => {
       int24(head);
-      fn(v);
+      if (v == null || v == undefined) {
+        fn(defaultValue);
+      } else {
+        fn(v);
+      }
     };
   }
 

--- a/javascript/packages/fury/lib/util.ts
+++ b/javascript/packages/fury/lib/util.ts
@@ -44,4 +44,8 @@ export const safePropName = (prop: string) => {
     return prop;
 }
 
-export const isNodeEnv = typeof process === "object" && process.env.ECMA_ONLY !== 'true' && typeof require === "function";
+export const isNodeEnv: boolean =
+  typeof process !== "undefined" &&
+  process.versions != null &&
+  process.env.ECMA_ONLY !== 'true' &&
+  process.versions.node != null;

--- a/javascript/packages/fury/package.json
+++ b/javascript/packages/fury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@furyjs/fury",
-  "version": "0.5.0.dev",
+  "version": "0.5.1.dev",
   "description": "A blazing fast multi-language serialization framework powered by jit and zero-copy",
   "main": "dist/index.js",
   "scripts": {

--- a/javascript/packages/fury/package.json
+++ b/javascript/packages/fury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@furyjs/fury",
-  "version": "0.5.1.dev",
+  "version": "0.5.1-beta",
   "description": "A blazing fast multi-language serialization framework powered by jit and zero-copy",
   "main": "dist/index.js",
   "scripts": {

--- a/javascript/packages/fury/package.json
+++ b/javascript/packages/fury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@furyjs/fury",
-  "version": "0.5.1-beta",
+  "version": "0.5.2-beta",
   "description": "A blazing fast multi-language serialization framework powered by jit and zero-copy",
   "main": "dist/index.js",
   "scripts": {

--- a/javascript/test/object.test.ts
+++ b/javascript/test/object.test.ts
@@ -225,6 +225,22 @@ describe('object', () => {
       expect(error.message).toBe("root type should be object");
     }
   });
+
+  test("should partial record work", () => {
+    const hps = undefined;
+    const description = Type.object('ws-channel-protocol', {
+        kind: Type.string(),
+        path: Type.string(),
+    });
+
+    const fury = new Fury({ hps });
+    const { serialize, deserialize } = fury.registerSerializer(description);
+    const bin = serialize({
+        kind: "123",
+    });
+    const obj = deserialize(bin);
+    expect({kind: "123", path: ""}).toEqual(obj)
+})
 });
 
 


### PR DESCRIPTION
## What do these changes do?
1. JavaScript is a dynamic language, so the object being serialized may lack certain properties. We should handle partial objects by adding default values for non-referencable types and making the description of object field types optional.

2. Sometimes, webpack may mock the process object, which can break environment detection. To mitigate this, we can detect the process.version.node property, as it is usually not mocked.

## Related issue number

Closes #1207

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
