### PR TITLE
[JavaScript] Fix register a description twice will get undefined serializer

### DIFF
--- a/javascript/packages/fury/lib/codeGen.ts
+++ b/javascript/packages/fury/lib/codeGen.ts
@@ -129,7 +129,7 @@ export const genSerializer = (fury: Fury, description: TypeDescription) => {
     const { genDeclaration, finish } = typeHandlerDeclaration(fury);
     const tag = Cast<ObjectTypeDescription>(description).options?.tag;
     if (fury.classResolver.getSerializerByTag(tag)) {
-        return;
+        return fury.classResolver.getSerializerByTag(tag);
     }
     
     fury.classResolver.registerSerializerByTag(tag, fury.classResolver.getSerializerById(InternalSerializerType.ANY));

--- a/javascript/packages/fury/package.json
+++ b/javascript/packages/fury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@furyjs/fury",
-  "version": "0.5.2-beta",
+  "version": "0.5.3-beta",
   "description": "A blazing fast multi-language serialization framework powered by jit and zero-copy",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?


I found an issue that if we register a description twice, in the second times, the result of `genSerializer` is undefined.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
