### PR TITLE
[C++] Support iterable types in RowEncodeTrait

### DIFF
--- a/src/fury/encoder/row_encoder_test.cc
+++ b/src/fury/encoder/row_encoder_test.cc
@@ -18,8 +18,8 @@
 #include <type_traits>
 
 #include "fury/encoder/row_encode_trait.h"
-#include "src/fury/encoder/row_encoder.h"
-#include "src/fury/row/writer.h"
+#include "fury/encoder/row_encoder.h"
+#include "fury/row/writer.h"
 
 namespace fury {
 

--- a/src/fury/meta/type_traits.h
+++ b/src/fury/meta/type_traits.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <iterator>
 #include <type_traits>
 
 namespace fury {
@@ -70,6 +71,31 @@ struct IsOneOf : std::disjunction<std::is_same<T, Args>...> {};
 template <typename T, typename... Args>
 using EnableIfIsOneOf =
     typename std::enable_if<IsOneOf<T, Args...>::value, T>::type;
+
+namespace details {
+using std::begin;
+using std::end;
+
+template <typename T,
+          typename U = std::void_t<
+              decltype(*begin(std::declval<T &>()),
+                       ++std::declval<decltype(begin(std::declval<T &>())) &>(),
+                       begin(std::declval<T &>()) != end(std::declval<T &>()))>>
+std::true_type IsIterableImpl(int);
+
+template <typename T> std::false_type IsIterableImpl(...);
+
+template <typename T> struct GetValueTypeImpl {
+  using type = std::remove_reference_t<decltype(*begin(std::declval<T &>()))>;
+};
+} // namespace details
+
+template <typename T>
+constexpr inline bool IsIterable =
+    decltype(details::IsIterableImpl<T>(0))::value;
+
+template <typename T>
+using GetValueType = typename details::GetValueTypeImpl<T>::type;
 
 } // namespace meta
 

--- a/src/fury/meta/type_traits_test.cc
+++ b/src/fury/meta/type_traits_test.cc
@@ -15,6 +15,9 @@
  */
 
 #include "gtest/gtest.h"
+#include <deque>
+#include <initializer_list>
+#include <list>
 
 #include "fury/meta/field_info.h"
 #include "src/fury/meta/type_traits.h"
@@ -58,6 +61,20 @@ TEST(Meta, IsUnique) {
   static_assert(IsUnique<1, false, true, 3, &A::x>::value);
   static_assert(!IsUnique<1, false, true, false, &A::x>::value);
   static_assert(!IsUnique<1, false, true, &A::x, 1>::value);
+}
+
+TEST(Meta, IsIterable) {
+  static_assert(IsIterable<std::vector<int>>);
+  static_assert(IsIterable<std::vector<std::vector<int>>>);
+  static_assert(IsIterable<std::deque<float>>);
+  static_assert(IsIterable<std::list<int>>);
+  static_assert(IsIterable<std::set<int>>);
+  static_assert(IsIterable<std::map<int, std::vector<unsigned>>>);
+  static_assert(IsIterable<struct A[10]>);
+  static_assert(IsIterable<float[2][2]>);
+  static_assert(IsIterable<std::initializer_list<A>>);
+  static_assert(IsIterable<std::string>);
+  static_assert(IsIterable<std::string_view>);
 }
 
 } // namespace test

--- a/src/fury/row/writer.h
+++ b/src/fury/row/writer.h
@@ -210,6 +210,8 @@ public:
 
   int size() { return cursor() - starting_offset_; }
 
+  std::shared_ptr<arrow::ListType> type() { return type_; }
+
 private:
   std::shared_ptr<arrow::ListType> type_;
   int element_size_;


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

In this PR we support any iterable types for `RowEncodeTrait` and its combination with struct types, e.g.
```c++
std::vector<int>

// nested array type
std::vector<std::vector<int>>

// class type in array type
struct A { ... }
std::vector<A>

// array in class type
struct B {
  std::vector<...> field1;
  ...
}
```

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
