### PR TITLE
[C++] Support iterable types for RowEncoder

### DIFF
--- a/src/fury/encoder/row_encode_trait.h
+++ b/src/fury/encoder/row_encode_trait.h
@@ -95,7 +95,7 @@ template <typename C> struct DefaultWriteVisitor {
 
   DefaultWriteVisitor(C &cont) : cont(cont) {}
 
-  template <typename> void Visit(std::unique_ptr<RowWriter> writer) {
+  template <typename, typename T> void Visit(std::unique_ptr<T> writer) {
     cont.push_back(std::move(writer));
   }
 };

--- a/src/fury/row/writer.h
+++ b/src/fury/row/writer.h
@@ -118,12 +118,12 @@ public:
     }
   }
 
+  virtual ~Writer() = default;
+
 protected:
   explicit Writer(int bytes_before_bitmap);
 
   explicit Writer(Writer *parent_writer, int bytes_before_bitmap);
-
-  virtual ~Writer() = default;
 
   std::shared_ptr<Buffer> buffer_;
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

In this PR, we support iterable types for `RowEncoder`.
Refer to `src/fury/encoder/row_encoder_test.cc` for how to use.

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
