### PR TITLE
[JavaScript] Implements tuple serializer

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -9,5 +9,8 @@
   "workspaces": [
     "packages/hps",
     "packages/fury"
-  ]
+  ],
+  "devDependencies": {
+    "prettier": "^3.1.0"
+  }
 }

--- a/javascript/packages/fury/lib/codeGen.ts
+++ b/javascript/packages/fury/lib/codeGen.ts
@@ -73,13 +73,13 @@ function typeHandlerDeclaration(fury: Fury) {
     const genBuiltinDeclaration = (type: number) => {
         const name = `type_${type}`.replace('-', '_');
         return addDeclar(name, `
-        const ${name} = classResolver.getSerializerById(${type})`);
+    const ${name} = classResolver.getSerializerById(${type})`);
     }
 
     const genTagDeclaration = (tag: string) => {
         const name = `tag_${count++}`;
         return addDeclar(name, `
-        const ${name} = classResolver.getSerializerByTag("${replaceBackslashAndQuote(tag)}")`, tag);
+    const ${name} = classResolver.getSerializerByTag("${replaceBackslashAndQuote(tag)}")`, tag);
     }
 
     const genDeclaration = (description: TypeDescription): string => {
@@ -97,21 +97,21 @@ function typeHandlerDeclaration(fury: Fury) {
 
                 const name = `tuple_${names.join('_')}`;
                 return addDeclar(name, `
-                const ${name} = tupleSerializer(fury, [${names.join(', ')}])`
+    const ${name} = tupleSerializer(fury, [${names.join(', ')}])`
                 )
             }
 
             const inner = genDeclaration(Cast<ArrayTypeDescription>(description).options.inner);
             const name = `array_${inner}`;
             return addDeclar(name, `
-                const ${name} = arraySerializer(fury, ${inner})`
+    const ${name} = arraySerializer(fury, ${inner})`
             )
         }
         if (description.type === InternalSerializerType.FURY_SET) {
             const inner = genDeclaration(Cast<SetTypeDescription>(description).options.key);
             const name = `set_${inner}`;
             return addDeclar(name, `
-                const ${name} = setSerializer(fury, ${inner})`
+    const ${name} = setSerializer(fury, ${inner})`
             )
         }
         if (description.type === InternalSerializerType.MAP) {
@@ -120,7 +120,7 @@ function typeHandlerDeclaration(fury: Fury) {
 
             const name = `map_${key}_${value}`;
             return addDeclar(name, `
-                const ${name} = mapSerializer(fury, ${key}, ${value})`
+    const ${name} = mapSerializer(fury, ${key}, ${value})`
             )
         }
         return genBuiltinDeclaration(description.type);

--- a/javascript/packages/fury/lib/codeGen.ts
+++ b/javascript/packages/fury/lib/codeGen.ts
@@ -139,7 +139,7 @@ function typeHandlerDeclaration(fury: Fury) {
     }
 }
 
-export const createFuncFromDescription = (fury: Fury, description: TypeDescription) => {
+export const generateInlineCode = (fury: Fury, description: TypeDescription) => {
     const options = Cast<ObjectTypeDescription>(description).options;
     const tag = options?.tag;
     const { genDeclaration, finish } = typeHandlerDeclaration(fury);
@@ -209,7 +209,7 @@ export const genSerializer = (fury: Fury, description: TypeDescription) => {
     
     fury.classResolver.registerSerializerByTag(tag, fury.classResolver.getSerializerById(InternalSerializerType.ANY));
 
-    const func = createFuncFromDescription(fury, description);
+    const func = generateInlineCode(fury, description);
     return fury.classResolver.registerSerializerByTag(tag, func()(fury, {
         InternalSerializerType,
         RefFlags,

--- a/javascript/packages/fury/lib/description.ts
+++ b/javascript/packages/fury/lib/description.ts
@@ -35,6 +35,14 @@ export interface ArrayTypeDescription extends TypeDescription {
     }
 }
 
+export interface TupleTypeDescription extends TypeDescription {
+    options: {
+        isTuple: true,
+        inner: TypeDescription[];
+    }
+}
+
+
 export interface SetTypeDescription extends TypeDescription {
     options: {
         key: TypeDescription;
@@ -80,6 +88,14 @@ type MapProps<T> = T extends {
     ? Map<ToRecordType<T2>, ToRecordType<T3> | null>
     : unknown;
 
+type TupleProps<T> = T extends {
+        options: {
+            inner: infer T2 extends readonly[...TypeDescription[]];
+        };
+    }
+        ? { [K in keyof T2]: ToRecordType<T2[K]> }
+        : unknown;
+
 type SetProps<T> = T extends {
     options: {
         key: infer T2 extends TypeDescription;
@@ -96,6 +112,10 @@ export type ToRecordType<T> = T extends {
         type: InternalSerializerType.STRING;
     }
     ? string
+    : T extends {
+        type: InternalSerializerType.TUPLE;
+    }
+    ? TupleProps<T>
     : T extends {
         type:
         | InternalSerializerType.UINT8
@@ -161,6 +181,15 @@ export const Type = {
             type: InternalSerializerType.ARRAY as const,
             options: {
                 inner: def,
+            },
+        };
+    },
+    tuple<T1 extends readonly [...readonly TypeDescription[]]>(t1: T1) {
+        return {
+            type: InternalSerializerType.TUPLE as const,
+            options: {
+                isTuple: true,
+                inner: t1,
             },
         };
     },

--- a/javascript/packages/fury/lib/internalSerializer/tuple.ts
+++ b/javascript/packages/fury/lib/internalSerializer/tuple.ts
@@ -18,7 +18,7 @@ import { InternalSerializerType, Serializer } from "../type";
 import { Fury } from "../type";
 
 
-export const tupleSerializer = (fury: Fury, ...items: Serializer[]) => {
+export const tupleSerializer = (fury: Fury, serializers: Serializer[]) => {
     const { binaryReader, binaryWriter, referenceResolver } = fury;
 
     const { pushReadObject } = referenceResolver;
@@ -31,7 +31,7 @@ export const tupleSerializer = (fury: Fury, ...items: Serializer[]) => {
             const result = new Array(len);
             pushReadObject(result);
             for (let i = 0; i < result.length; i++) {
-                const item = items[i];
+                const item = serializers[i];
                 result[i] = item.read();
             }
             return result;
@@ -39,9 +39,9 @@ export const tupleSerializer = (fury: Fury, ...items: Serializer[]) => {
         write: referenceResolver.withNullableOrRefWriter(InternalSerializerType.TUPLE, (v: any[]) => {
             writeVarInt32(v.length);
             
-            for (let i = 0; i < v.length; i++) {
+            for (let i = 0; i < serializers.length; i++) {
                 const x = v[i];
-                const item = items[i];
+                const item = serializers[i];
                 reserves(item.config().reserve);
                 item.write(x);
             }

--- a/javascript/packages/fury/lib/internalSerializer/tuple.ts
+++ b/javascript/packages/fury/lib/internalSerializer/tuple.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InternalSerializerType, Serializer } from "../type";
+import { Fury } from "../type";
+
+
+export const tupleSerializer = (fury: Fury, ...items: Serializer[]) => {
+    const { binaryReader, binaryWriter, referenceResolver } = fury;
+
+    const { pushReadObject } = referenceResolver;
+    const { varInt32: writeVarInt32, reserve: reserves } = binaryWriter;
+    const { varInt32: readVarInt32 } = binaryReader;
+
+    return {
+        ...referenceResolver.deref(() => {
+            const len = readVarInt32();
+            const result = new Array(len);
+            pushReadObject(result);
+            for (let i = 0; i < result.length; i++) {
+                const item = items[i];
+                result[i] = item.read();
+            }
+            return result;
+        }),
+        write: referenceResolver.withNullableOrRefWriter(InternalSerializerType.TUPLE, (v: any[]) => {
+            writeVarInt32(v.length);
+            
+            for (let i = 0; i < v.length; i++) {
+                const x = v[i];
+                const item = items[i];
+                reserves(item.config().reserve);
+                item.write(x);
+            }
+        }),
+        config: () => {
+            return {
+                reserve: 7,
+            }
+        }
+    }
+}

--- a/javascript/packages/fury/lib/internalSerializer/tuple.ts
+++ b/javascript/packages/fury/lib/internalSerializer/tuple.ts
@@ -30,20 +30,19 @@ export const tupleSerializer = (fury: Fury, serializers: Serializer[]) => {
             const len = readVarInt32();
             const result = new Array(len);
             pushReadObject(result);
-            for (let i = 0; i < result.length; i++) {
+            for (let i = 0; i < len; i++) {
                 const item = serializers[i];
                 result[i] = item.read();
             }
             return result;
         }),
         write: referenceResolver.withNullableOrRefWriter(InternalSerializerType.TUPLE, (v: any[]) => {
-            writeVarInt32(v.length);
+            writeVarInt32(serializers.length);
             
             for (let i = 0; i < serializers.length; i++) {
-                const x = v[i];
                 const item = serializers[i];
                 reserves(item.config().reserve);
-                item.write(x);
+                item.write(v[i]);
             }
         }),
         config: () => {

--- a/javascript/packages/fury/lib/type.ts
+++ b/javascript/packages/fury/lib/type.ts
@@ -23,9 +23,10 @@ export type BinaryWriter = ReturnType<typeof BinaryWriter>
 export type BinaryReader = ReturnType<typeof BinaryReader>
 
 
-export enum InternalSerializerType{
-    STRING = 13,
+export enum InternalSerializerType {
+	STRING = 13,
 	ARRAY = 25,
+	TUPLE = 25,
 	MAP = 30,
 	BOOL = 1,
 	UINT8 = 2,
@@ -41,7 +42,7 @@ export enum InternalSerializerType{
 	BINARY = 14,
 	DATE = 16,
 	TIMESTAMP = 18,
-    FURY_TYPE_TAG = 256,
+	FURY_TYPE_TAG = 256,
 	FURY_SET = 257,
 	FURY_PRIMITIVE_BOOL_ARRAY = 258,
 	FURY_PRIMITIVE_SHORT_ARRAY = 259,

--- a/javascript/test/__snapshots__/codeGen.test.ts.snap
+++ b/javascript/test/__snapshots__/codeGen.test.ts.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`codeGen can generate tuple declaration code 1`] = `
+"function anonymous(
+) {
+
+return function (fury, scope) {
+    const { referenceResolver, binaryWriter, classResolver, binaryReader } = fury;
+    const { writeNullOrRef, pushReadObject } = referenceResolver;
+    const { RefFlags, InternalSerializerType, arraySerializer, tupleSerializer, mapSerializer, setSerializer } = scope;
+    
+        const tag_0 = classResolver.getSerializerByTag("example.foo.1")
+        const tag_1 = classResolver.getSerializerByTag("example.foo.2")
+                const tuple_tag_0_tag_1 = tupleSerializer(fury, [tag_0, tag_1])
+        const tag_5 = classResolver.getSerializerByTag("example.bar.1")
+        const tag_6 = classResolver.getSerializerByTag("example.bar.2")
+                const tuple_tag_0_tag_5_tag_6 = tupleSerializer(fury, [tag_0, tag_5, tag_6])
+    const tagBuffer = classResolver.tagToBuffer("tuple-object-wrapper");
+    const bufferLen = tagBuffer.byteLength;
+
+    const reserves = tag_0.config().reserve + tag_1.config().reserve + tuple_tag_0_tag_1.config().reserve + tag_5.config().reserve + tag_6.config().reserve + tuple_tag_0_tag_5_tag_6.config().reserve;
+    return {
+        ...referenceResolver.deref(() => {
+            const hash = binaryReader.int32();
+            if (hash !== 16469457) {
+                throw new Error("validate hash failed: tuple-object-wrapper. expect 16469457, but got" + hash);
+            }
+            {
+                
+    // relation tag: tuple-object-wrapper
+    const result = {
+        tuple1: null,
+tuple1_: null,
+tuple2: null,
+tuple2_: null
+    };
+    pushReadObject(result);
+    result.tuple1 = tuple_tag_0_tag_1.read();
+result.tuple1_ = tuple_tag_0_tag_1.read();
+result.tuple2 = tuple_tag_0_tag_5_tag_6.read();
+result.tuple2_ = tuple_tag_0_tag_5_tag_6.read()
+    return result;
+
+            }
+        }),
+        write: referenceResolver.withNullableOrRefWriter(InternalSerializerType.FURY_TYPE_TAG, (v) => {
+            classResolver.writeTag(binaryWriter, "tuple-object-wrapper", tagBuffer, bufferLen);
+            binaryWriter.int32(16469457);
+            binaryWriter.reserve(reserves);
+            tuple_tag_0_tag_1.write(v.tuple1);
+tuple_tag_0_tag_1.write(v.tuple1_);
+tuple_tag_0_tag_5_tag_6.write(v.tuple2);
+tuple_tag_0_tag_5_tag_6.write(v.tuple2_)
+        }),
+        config() {
+            return {
+                reserve: bufferLen + 8,
+            }
+        }
+    }
+}
+
+}"
+`;
+
+exports[`codeGen can generate tuple declaration code 2`] = `
+"function anonymous(
+) {
+
+return function (fury, scope) {
+    const { referenceResolver, binaryWriter, classResolver, binaryReader } = fury;
+    const { writeNullOrRef, pushReadObject } = referenceResolver;
+    const { RefFlags, InternalSerializerType, arraySerializer, tupleSerializer, mapSerializer, setSerializer } = scope;
+    
+        const type_13 = classResolver.getSerializerById(13)
+        const type_1 = classResolver.getSerializerById(1)
+        const type_6 = classResolver.getSerializerById(6)
+        const type_14 = classResolver.getSerializerById(14)
+                const tuple_type_14 = tupleSerializer(fury, [type_14])
+                const tuple_type_13_type_1_type_6_tuple_type_14 = tupleSerializer(fury, [type_13, type_1, type_6, tuple_type_14])
+    const tagBuffer = classResolver.tagToBuffer("tuple-object-type3-tag");
+    const bufferLen = tagBuffer.byteLength;
+
+    const reserves = type_13.config().reserve + type_1.config().reserve + type_6.config().reserve + type_14.config().reserve + tuple_type_14.config().reserve + tuple_type_13_type_1_type_6_tuple_type_14.config().reserve;
+    return {
+        ...referenceResolver.deref(() => {
+            const hash = binaryReader.int32();
+            if (hash !== 552) {
+                throw new Error("validate hash failed: tuple-object-type3-tag. expect 552, but got" + hash);
+            }
+            {
+                
+    // relation tag: tuple-object-type3-tag
+    const result = {
+        tuple: null
+    };
+    pushReadObject(result);
+    result.tuple = tuple_type_13_type_1_type_6_tuple_type_14.read()
+    return result;
+
+            }
+        }),
+        write: referenceResolver.withNullableOrRefWriter(InternalSerializerType.FURY_TYPE_TAG, (v) => {
+            classResolver.writeTag(binaryWriter, "tuple-object-type3-tag", tagBuffer, bufferLen);
+            binaryWriter.int32(552);
+            binaryWriter.reserve(reserves);
+            tuple_type_13_type_1_type_6_tuple_type_14.write(v.tuple)
+        }),
+        config() {
+            return {
+                reserve: bufferLen + 8,
+            }
+        }
+    }
+}
+
+}"
+`;

--- a/javascript/test/__snapshots__/codeGen.test.ts.snap
+++ b/javascript/test/__snapshots__/codeGen.test.ts.snap
@@ -9,12 +9,12 @@ return function (fury, scope) {
     const { writeNullOrRef, pushReadObject } = referenceResolver;
     const { RefFlags, InternalSerializerType, arraySerializer, tupleSerializer, mapSerializer, setSerializer } = scope;
     
-        const tag_0 = classResolver.getSerializerByTag("example.foo.1")
-        const tag_1 = classResolver.getSerializerByTag("example.foo.2")
-                const tuple_tag_0_tag_1 = tupleSerializer(fury, [tag_0, tag_1])
-        const tag_5 = classResolver.getSerializerByTag("example.bar.1")
-        const tag_6 = classResolver.getSerializerByTag("example.bar.2")
-                const tuple_tag_0_tag_5_tag_6 = tupleSerializer(fury, [tag_0, tag_5, tag_6])
+    const tag_0 = classResolver.getSerializerByTag("example.foo.1")
+    const tag_1 = classResolver.getSerializerByTag("example.foo.2")
+    const tuple_tag_0_tag_1 = tupleSerializer(fury, [tag_0, tag_1])
+    const tag_5 = classResolver.getSerializerByTag("example.bar.1")
+    const tag_6 = classResolver.getSerializerByTag("example.bar.2")
+    const tuple_tag_0_tag_5_tag_6 = tupleSerializer(fury, [tag_0, tag_5, tag_6])
     const tagBuffer = classResolver.tagToBuffer("tuple-object-wrapper");
     const bufferLen = tagBuffer.byteLength;
 
@@ -72,12 +72,12 @@ return function (fury, scope) {
     const { writeNullOrRef, pushReadObject } = referenceResolver;
     const { RefFlags, InternalSerializerType, arraySerializer, tupleSerializer, mapSerializer, setSerializer } = scope;
     
-        const type_13 = classResolver.getSerializerById(13)
-        const type_1 = classResolver.getSerializerById(1)
-        const type_6 = classResolver.getSerializerById(6)
-        const type_14 = classResolver.getSerializerById(14)
-                const tuple_type_14 = tupleSerializer(fury, [type_14])
-                const tuple_type_13_type_1_type_6_tuple_type_14 = tupleSerializer(fury, [type_13, type_1, type_6, tuple_type_14])
+    const type_13 = classResolver.getSerializerById(13)
+    const type_1 = classResolver.getSerializerById(1)
+    const type_6 = classResolver.getSerializerById(6)
+    const type_14 = classResolver.getSerializerById(14)
+    const tuple_type_14 = tupleSerializer(fury, [type_14])
+    const tuple_type_13_type_1_type_6_tuple_type_14 = tupleSerializer(fury, [type_13, type_1, type_6, tuple_type_14])
     const tagBuffer = classResolver.tagToBuffer("tuple-object-type3-tag");
     const bufferLen = tagBuffer.byteLength;
 

--- a/javascript/test/codeGen.test.ts
+++ b/javascript/test/codeGen.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TypeDescription, InternalSerializerType, ObjectTypeDescription } from '../packages/fury/index';
+import { describe, expect, test } from '@jest/globals';
+import { tupleObjectDescription, tupleObjectType3Description } from './fixtures/tuple';
+import { createFuncFromDescription } from '../packages/fury/lib/codeGen';
+import FuryInternal from '../packages/fury/lib/fury';
+
+describe('codeGen', () => {
+  test('can generate tuple declaration code', () => {
+    const fury = FuryInternal({ refTracking: true });
+    const fn = createFuncFromDescription(fury, tupleObjectDescription);
+    expect(fn.toString()).toMatchSnapshot();
+
+    const fn2 = createFuncFromDescription(fury, tupleObjectType3Description);
+    expect(fn2.toString()).toMatchSnapshot();
+  })
+})

--- a/javascript/test/codeGen.test.ts
+++ b/javascript/test/codeGen.test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { TypeDescription, InternalSerializerType, ObjectTypeDescription } from '../packages/fury/index';
 import { describe, expect, test } from '@jest/globals';
 import { tupleObjectDescription, tupleObjectType3Description } from './fixtures/tuple';
 import { createFuncFromDescription } from '../packages/fury/lib/codeGen';

--- a/javascript/test/codeGen.test.ts
+++ b/javascript/test/codeGen.test.ts
@@ -16,16 +16,16 @@
 
 import { describe, expect, test } from '@jest/globals';
 import { tupleObjectDescription, tupleObjectType3Description } from './fixtures/tuple';
-import { createFuncFromDescription } from '../packages/fury/lib/codeGen';
+import { generateInlineCode } from '../packages/fury/lib/codeGen';
 import FuryInternal from '../packages/fury/lib/fury';
 
 describe('codeGen', () => {
   test('can generate tuple declaration code', () => {
     const fury = FuryInternal({ refTracking: true });
-    const fn = createFuncFromDescription(fury, tupleObjectDescription);
+    const fn = generateInlineCode(fury, tupleObjectDescription);
     expect(fn.toString()).toMatchSnapshot();
 
-    const fn2 = createFuncFromDescription(fury, tupleObjectType3Description);
+    const fn2 = generateInlineCode(fury, tupleObjectType3Description);
     expect(fn2.toString()).toMatchSnapshot();
   })
 })

--- a/javascript/test/fixtures/tuple.ts
+++ b/javascript/test/fixtures/tuple.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { Type } from "../../packages/fury";
 
 export const tupleType1 = Type.tuple( [

--- a/javascript/test/fixtures/tuple.ts
+++ b/javascript/test/fixtures/tuple.ts
@@ -1,0 +1,55 @@
+import { Type } from "../../packages/fury";
+
+export const tupleType1 = Type.tuple( [
+  Type.object('example.foo.1',{
+    a: Type.object('example.foo.1.1',{
+      b: Type.string()
+    })
+  }),
+  Type.object('example.foo.2',{
+    a: Type.object('example.foo.2.1',{
+      c: Type.string()
+    })
+  })
+]);
+
+export const tupleType2 = Type.tuple( [
+  Type.object('example.foo.1',{
+    a: Type.object('example.foo.1.1',{
+      b: Type.string()
+    })
+  }),
+  Type.object('example.bar.1',{
+    a: Type.object('example.bar.1.1',{
+      b: Type.string()
+    })
+  }),
+  Type.object('example.bar.2',{
+    a: Type.object('example.bar.2.1',{
+      c: Type.string()
+    })
+  })
+]);
+
+export const tupleType3 = Type.tuple([
+  Type.string(),
+  Type.bool(),
+  Type.uint32(),
+  Type.tuple([
+    Type.binary()
+  ])
+])
+
+export const tupleObjectTag = 'tuple-object-wrapper';
+
+export const tupleObjectDescription =  Type.object(tupleObjectTag, {
+  tuple1: tupleType1,
+  tuple1_: tupleType1,
+  tuple2: tupleType2,
+  tuple2_: tupleType2,
+});
+
+export const tupleObjectType3Tag = 'tuple-object-type3-tag';
+export const tupleObjectType3Description = Type.object(tupleObjectType3Tag, {
+  tuple: tupleType3
+})

--- a/javascript/test/tuple.test.ts
+++ b/javascript/test/tuple.test.ts
@@ -37,7 +37,29 @@ describe('tuple', () => {
     );
     expect(result).toEqual(raw)
   });
+
+  const type3Raw = {
+    tuple: [
+      "1234",
+      false,
+      2333,
+      [
+        Buffer.alloc(10)
+      ]
+    ]
+  };
+
   test('tuple support other types', () => {
+    const fury = new Fury({ refTracking: true });
+    const { serialize, deserialize } = fury.registerSerializer(tupleObjectType3Description);
+
+    const input = serialize(type3Raw);
+    const result = deserialize(
+      input
+    );
+    expect(result).toEqual(type3Raw)
+  });
+  test('tuple will ignore items which index out of bounds', () => {
     const fury = new Fury({ refTracking: true });
     const { serialize, deserialize } = fury.registerSerializer(tupleObjectType3Description);
     const raw = {
@@ -47,7 +69,10 @@ describe('tuple', () => {
         2333,
         [
           Buffer.alloc(10)
-        ]
+        ],
+        1234,
+        12345,
+        false
       ]
     };
  
@@ -55,6 +80,6 @@ describe('tuple', () => {
     const result = deserialize(
       input
     );
-    expect(result).toEqual(raw)
+    expect(result).toEqual(type3Raw)
   });
 })

--- a/javascript/test/tuple.test.ts
+++ b/javascript/test/tuple.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 The Fury Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Fury, { TypeDescription, InternalSerializerType, Type } from '../packages/fury/index';
+import { describe, expect, test } from '@jest/globals';
+
+describe('tuple', () => {
+  test('should tuple work', () => {
+    const description =  Type.object('aasdasd', {
+      tuple: Type.tuple( [
+        Type.object('example.foo.1',{
+          a: Type.object('example.foo.1.1',{
+            b: Type.string()
+          })
+        }),
+        Type.object('example.foo.2',{
+          a: Type.object('example.foo.2.1',{
+            c: Type.string()
+          })
+        })
+      ])
+    });
+
+    const fury = new Fury({ refTracking: true });
+    const { serialize, deserialize } = fury.registerSerializer(description);
+    const tuple = [{a: {b:'1'}}, {a: {c: '2'}}] as [{a: {b: string}}, {a: {c: string}}];
+    const raw = {
+      tuple,
+    };
+ 
+    const input = serialize(raw);
+    const result = deserialize(
+      input
+    );
+    expect(result).toEqual(raw)
+  });
+})

--- a/javascript/test/tuple.test.ts
+++ b/javascript/test/tuple.test.ts
@@ -14,31 +14,41 @@
  * limitations under the License.
  */
 
-import Fury, { TypeDescription, InternalSerializerType, Type } from '../packages/fury/index';
+import Fury from '../packages/fury/index';
 import { describe, expect, test } from '@jest/globals';
+import { tupleObjectDescription, tupleObjectType3Description } from './fixtures/tuple';
 
 describe('tuple', () => {
   test('should tuple work', () => {
-    const description =  Type.object('aasdasd', {
-      tuple: Type.tuple( [
-        Type.object('example.foo.1',{
-          a: Type.object('example.foo.1.1',{
-            b: Type.string()
-          })
-        }),
-        Type.object('example.foo.2',{
-          a: Type.object('example.foo.2.1',{
-            c: Type.string()
-          })
-        })
-      ])
-    });
-
     const fury = new Fury({ refTracking: true });
-    const { serialize, deserialize } = fury.registerSerializer(description);
-    const tuple = [{a: {b:'1'}}, {a: {c: '2'}}] as [{a: {b: string}}, {a: {c: string}}];
+    const { serialize, deserialize } = fury.registerSerializer(tupleObjectDescription);
+    const tuple1 = [{a: {b:'1'}}, {a: {c: '2'}}] as [{a: {b: string}}, {a: {c: string}}];
+    const tuple2 =  [{a: {b:'1'}}, {a: {b:'1'}}, {a: {c: '2'}}] as [{a: {b: string}}, {a: {b: string}}, {a: {c: string}}];
     const raw = {
-      tuple,
+      tuple1: tuple1,
+      tuple1_: tuple1,
+      tuple2: tuple2,
+      tuple2_: tuple2
+    };
+ 
+    const input = serialize(raw);
+    const result = deserialize(
+      input
+    );
+    expect(result).toEqual(raw)
+  });
+  test('tuple support other types', () => {
+    const fury = new Fury({ refTracking: true });
+    const { serialize, deserialize } = fury.registerSerializer(tupleObjectType3Description);
+    const raw = {
+      tuple: [
+        "1234",
+        false,
+        2333,
+        [
+          Buffer.alloc(10)
+        ]
+      ]
     };
  
     const input = serialize(raw);


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Implements tuple serializer

In many language, there is a data structure called tuple, but the fury specification has not defined tuple behaviours.

so I am using Array as Tuple.

and also thanks to @wangweipeng2 for his teaching, he also has a lot contribution for this pr.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
