### PR TITLE
[Java] disable async compilation for graalvm

### DIFF
--- a/docs/guide/graalvm_guide.md
+++ b/docs/guide/graalvm_guide.md
@@ -24,6 +24,9 @@ Another benefit using fury is that you don't have to configure [reflection json]
 very tedious, cumbersome and inconvenient. When using fury, you just need to invoke 
 `io.fury.Fury.register(Class<?>, boolean)` for every type you want to serialize.
 
+Note that Fury `asyncCompilationEnabled` option will be disabled automatically for graalvm native image since graalvm 
+native image doesn't support JIT at the image run time.
+
 ## Not thread-safe Fury
 Example:
 ```java

--- a/java/fury-core/src/main/java/io/fury/config/FuryBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/config/FuryBuilder.java
@@ -258,9 +258,9 @@ public final class FuryBuilder {
    * Whether enable async compilation. If enabled, serialization will use interpreter mode
    * serialization first and switch to jit serialization after async serializer jit for a class \ is
    * finished.
-   * <p>
-   * This option will be disabled automatically for graalvm native image since graalvm native image
-   * doesn't support JIT at the image run time.
+   *
+   * <p>This option will be disabled automatically for graalvm native image since graalvm native
+   * image doesn't support JIT at the image run time.
    *
    * @see Config#isAsyncCompilationEnabled()
    */

--- a/java/fury-core/src/main/java/io/fury/config/FuryBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/config/FuryBuilder.java
@@ -26,6 +26,7 @@ import io.fury.serializer.ObjectStreamSerializer;
 import io.fury.serializer.Serializer;
 import io.fury.serializer.TimeSerializers;
 import io.fury.serializer.collection.GuavaCollectionSerializers;
+import io.fury.util.GraalvmSupport;
 import io.fury.util.LoggerFactory;
 import io.fury.util.Platform;
 import java.util.Objects;
@@ -304,6 +305,10 @@ public final class FuryBuilder {
     }
     if (suppressClassRegistrationWarnings == null) {
       suppressClassRegistrationWarnings = !requireClassRegistration;
+    }
+    if (GraalvmSupport.IN_GRAALVM_NATIVE_IMAGE && asyncCompilationEnabled) {
+      LOG.info("Use sync compilation for graalvm native image since it doesn't support JIT.");
+      asyncCompilationEnabled = false;
     }
   }
 

--- a/java/fury-core/src/main/java/io/fury/config/FuryBuilder.java
+++ b/java/fury-core/src/main/java/io/fury/config/FuryBuilder.java
@@ -258,6 +258,9 @@ public final class FuryBuilder {
    * Whether enable async compilation. If enabled, serialization will use interpreter mode
    * serialization first and switch to jit serialization after async serializer jit for a class \ is
    * finished.
+   * <p>
+   * This option will be disabled automatically for graalvm native image since graalvm native image
+   * doesn't support JIT at the image run time.
    *
    * @see Config#isAsyncCompilationEnabled()
    */


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Graalvm doesn't support JIT, we should disable fury async compilation for graalvm, otherwise threads will be created at graalvm build time, which is disallowed, and Fury codegen may not be finished at graalvm build time too.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
 #678 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
