### PR TITLE
[Rust] Remove unnecessary abstraction

### DIFF
--- a/rust/fury-derive/src/fury_row.rs
+++ b/rust/fury-derive/src/fury_row.rs
@@ -32,7 +32,7 @@ pub fn derive_row(ast: &syn::DeriveInput) -> TokenStream {
 
         quote! {
             let mut callback_info = struct_writer.write_start(#index);
-            <#ty as fury::__derive::Row<'a>>::write(&v.#ident, struct_writer.borrow_writer());
+            <#ty as fury::__derive::Row<'a>>::write(&v.#ident, struct_writer.get_writer());
             struct_writer.write_end(callback_info);
         }
     });
@@ -44,7 +44,6 @@ pub fn derive_row(ast: &syn::DeriveInput) -> TokenStream {
 
         quote! {
             pub fn #getter_name(&self) -> <#ty as fury::__derive::Row<'a>>::ReadResult {
-                use fury::__derive::RowViewer;
                 let bytes = self.struct_data.get_field_bytes(#index);
                 <#ty as fury::__derive::Row<'a>>::cast(bytes)
             }
@@ -70,7 +69,6 @@ pub fn derive_row(ast: &syn::DeriveInput) -> TokenStream {
             type ReadResult = #getter<'a>;
 
             fn write(v: &Self, writer: &mut fury::__derive::Writer) {
-                use fury::__derive::RowWriter;
                 let mut struct_writer = fury::__derive::StructWriter::new(#num_fields, writer);
                 #(#write_exprs);*;
             }

--- a/rust/fury/src/lib.rs
+++ b/rust/fury/src/lib.rs
@@ -28,7 +28,7 @@ pub use serializer::to_buffer;
 pub mod __derive {
     pub use crate::buffer::{Reader, Writer};
     pub use crate::deserializer::{Deserialize, DeserializerState};
-    pub use crate::row::{Row, RowViewer, RowWriter, StructViewer, StructWriter};
+    pub use crate::row::{Row, StructViewer, StructWriter};
     pub use crate::serializer::{Serialize, SerializerState};
     pub use crate::types::{compute_struct_hash, FieldType, FuryMeta, SIZE_OF_REF_AND_TYPE};
     pub use crate::Error;

--- a/rust/fury/src/row/mod.rs
+++ b/rust/fury/src/row/mod.rs
@@ -17,6 +17,6 @@ mod reader;
 mod row;
 mod writer;
 
-pub use reader::{from_row, ArrayViewer, RowViewer, StructViewer};
+pub use reader::{from_row, ArrayViewer, StructViewer};
 pub use row::Row;
-pub use writer::{to_row, ArrayWriter, RowWriter, StructWriter};
+pub use writer::{to_row, ArrayWriter, StructWriter};

--- a/rust/fury/src/row/row.rs
+++ b/rust/fury/src/row/row.rs
@@ -19,8 +19,8 @@ use std::collections::BTreeMap;
 use std::marker::PhantomData;
 
 use super::{
-    reader::{ArrayViewer, MapViewer, RowViewer},
-    writer::{ArrayWriter, MapWriter, RowWriter},
+    reader::{ArrayViewer, MapViewer},
+    writer::{ArrayWriter, MapWriter},
 };
 
 pub trait Row<'a> {
@@ -157,7 +157,7 @@ impl<'a, T: Row<'a>> Row<'a> for Vec<T> {
         let mut array_writer = ArrayWriter::new(v.len(), writer);
         v.iter().enumerate().for_each(|(idx, item)| {
             let callback_info = array_writer.write_start(idx);
-            <T as Row>::write(item, array_writer.borrow_writer());
+            <T as Row>::write(item, array_writer.get_writer());
             array_writer.write_end(callback_info);
         });
     }
@@ -217,19 +217,19 @@ impl<'a, T1: Row<'a> + Ord, T2: Row<'a> + Ord> Row<'a> for BTreeMap<T1, T2> {
         let mut map_writter = MapWriter::new(writer);
         {
             let callback_info = map_writter.write_start(0);
-            let mut array_writer = ArrayWriter::new(v.len(), map_writter.borrow_writer());
+            let mut array_writer = ArrayWriter::new(v.len(), map_writter.get_writer());
             v.keys().enumerate().for_each(|(idx, item)| {
                 let callback_info = array_writer.write_start(idx);
-                <T1 as Row>::write(item, array_writer.borrow_writer());
+                <T1 as Row>::write(item, array_writer.get_writer());
                 array_writer.write_end(callback_info);
             });
             map_writter.write_end(callback_info);
         }
         {
-            let mut array_writer = ArrayWriter::new(v.len(), map_writter.borrow_writer());
+            let mut array_writer = ArrayWriter::new(v.len(), map_writter.get_writer());
             v.values().enumerate().for_each(|(idx, item)| {
                 let callback_info = array_writer.write_start(idx);
-                <T2 as Row>::write(item, array_writer.borrow_writer());
+                <T2 as Row>::write(item, array_writer.get_writer());
                 array_writer.write_end(callback_info);
             });
         }


### PR DESCRIPTION
## What do these changes do?

1. Removing unnecessary abstractions, as unreachable code can be confusing for developers.
2. Use a FieldWriteHepler to reuse code instead of implement trait to avoid unreachable code

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #1224 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
