### PR TITLE
[JavaScript] Add more methods for BinaryReader

### DIFF
--- a/javascript/packages/fury/lib/internalSerializer/string.ts
+++ b/javascript/packages/fury/lib/internalSerializer/string.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Fury, LATIN1 } from "../type";
+import { Fury } from "../type";
 import { InternalSerializerType, RefFlags } from "../type";
 
 
@@ -22,18 +22,11 @@ import { InternalSerializerType, RefFlags } from "../type";
 export default (fury: Fury) => {
     const { binaryReader, binaryWriter, referenceResolver } = fury;
     const { stringOfVarInt32: writeStringOfVarInt32, int8 } = binaryWriter
-    const { varInt32: readVarInt32, stringUtf8: readStringUtf8, uint8: readUInt8, stringLatin1, } = binaryReader;
+    const { stringOfVarInt32: readStringOfVarInt32 } = binaryReader;
 
     return {
-        ...referenceResolver.deref(fury.config.useLatin1 ? () => {
-            const type = readUInt8();
-            const len = readVarInt32();
-            const result = type === LATIN1 ? stringLatin1(len) : readStringUtf8(len);
-            return result;
-        } : () => {
-            const len = readVarInt32();
-            const result = readStringUtf8(len);
-            return result;
+        ...referenceResolver.deref(() => {
+            return readStringOfVarInt32();
         }),
         write: referenceResolver.withNotNullableWriter(InternalSerializerType.STRING, "", (v: string) => {
             writeStringOfVarInt32(v);

--- a/javascript/packages/fury/lib/reader.ts
+++ b/javascript/packages/fury/lib/reader.ts
@@ -99,6 +99,13 @@ export const BinaryReader = (config: Config) => {
     return result;
   }
 
+  function stringUtf8OfVarint32() {
+    const len = varInt32();
+    const result = buffer.utf8Slice(cursor, cursor + len);
+    cursor += len;
+    return result;
+  }
+
   function stringLatin1Fast(len: number) {
     const result = bigString.substring(cursor, cursor + len);
     cursor += len;
@@ -114,6 +121,12 @@ export const BinaryReader = (config: Config) => {
   function binary(len: number) {
     const result = alloc(len);
     buffer.copy(result, 0, cursor, cursor + len);
+    cursor += len;
+    return result;
+  }
+
+  function bufferRef(len: number) {
+    const result = buffer.subarray(cursor, cursor + len);
     cursor += len;
     return result;
   }
@@ -146,9 +159,11 @@ export const BinaryReader = (config: Config) => {
     varInt32,
     int8,
     buffer: binary,
+    bufferRef,
     uint8,
     reset,
     stringUtf8,
+    stringUtf8OfVarint32,
     stringLatin1: sliceStringEnable ? stringLatin1Fast : stringLatin1Slow,
     double,
     float,

--- a/javascript/test/io.test.ts
+++ b/javascript/test/io.test.ts
@@ -225,10 +225,7 @@ function num2Bin(num: number) {
             }
             {
                 reader.reset(ab);
-                if (config.useLatin1) {
-                    expect(reader.uint8()).toBe(1);
-                }
-                expect(reader.stringUtf8OfVarint32()).toBe(str);
+                expect(reader.stringOfVarInt32()).toBe(str);
             }
         });
 
@@ -249,10 +246,7 @@ function num2Bin(num: number) {
             }
             {
                 reader.reset(ab);
-                if (config.useLatin1) {
-                    expect(reader.uint8()).toBe(1);
-                }
-                expect(reader.stringUtf8OfVarint32()).toBe(str);
+                expect(reader.stringOfVarInt32()).toBe(str);
             }
         });
 

--- a/javascript/test/io.test.ts
+++ b/javascript/test/io.test.ts
@@ -213,13 +213,23 @@ function num2Bin(num: number) {
             writer.stringOfVarInt32(str);
             const ab = writer.dump();
             const reader = BinaryReader(config);
-            reader.reset(ab);
-            if (config.useLatin1) {
-                expect(reader.uint8()).toBe(1);
+
+            {
+                reader.reset(ab);
+                if (config.useLatin1) {
+                    expect(reader.uint8()).toBe(1);
+                }
+                const len = reader.varInt32();
+                expect(len).toBe(17);
+                expect(reader.stringUtf8(len)).toBe(str);
             }
-            const len = reader.varInt32();
-            expect(len).toBe(17);
-            expect(reader.stringUtf8(len)).toBe(str);
+            {
+                reader.reset(ab);
+                if (config.useLatin1) {
+                    expect(reader.uint8()).toBe(1);
+                }
+                expect(reader.stringUtf8OfVarint32()).toBe(str);
+            }
         });
 
         test('should long utf8 string work', () => {
@@ -228,13 +238,22 @@ function num2Bin(num: number) {
             writer.stringOfVarInt32(str);
             const ab = writer.dump();
             const reader = BinaryReader(config);
-            reader.reset(ab);
-            if (config.useLatin1) {
-                expect(reader.uint8()).toBe(1);
+            {
+                reader.reset(ab);
+                if (config.useLatin1) {
+                    expect(reader.uint8()).toBe(1);
+                }
+                const len = reader.varInt32();
+                expect(len).toBe(170);
+                expect(reader.stringUtf8(len)).toBe(str);
             }
-            const len = reader.varInt32();
-            expect(len).toBe(170);
-            expect(reader.stringUtf8(len)).toBe(str);
+            {
+                reader.reset(ab);
+                if (config.useLatin1) {
+                    expect(reader.uint8()).toBe(1);
+                }
+                expect(reader.stringUtf8OfVarint32()).toBe(str);
+            }
         });
 
         test('should buffer work', () => {
@@ -339,5 +358,3 @@ function num2Bin(num: number) {
         });
     });
 })
-
-

--- a/javascript/test/reader.test.ts
+++ b/javascript/test/reader.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { alloc } from '@furyjs/fury/lib/platformBuffer';
+import { BinaryReader } from '@furyjs/fury/lib/reader';
 import { Config } from '@furyjs/fury/lib/type';
 import { BinaryWriter } from '@furyjs/fury/lib/writer';
 import { describe, expect, test } from '@jest/globals';
@@ -55,3 +57,21 @@ const hps = process.env.enableHps ? require('@furyjs/hps') : null;
 })
 
 
+describe('reader', () => {
+
+    test('should bufferRef work', () => {
+        const bb = alloc(100);
+        bb.latin1Write("hello", 0);
+        const target = new Uint8Array(5);
+        bb.copy(target, 0, 0, 5);
+        expect([...target]).toEqual([ 104, 101, 108, 108, 111 ])
+
+        const reader = BinaryReader({});
+
+        reader.reset(bb);
+        const ref = reader.bufferRef(5);
+        ref[0] = 0;
+        bb.copy(target, 0, 0, 5);
+        expect([...target]).toEqual([ 0, 101, 108, 108, 111 ])
+    })
+})


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

Add more methods for BinaryReader

In real world scene, we need do many opreation on binary, it is better to have an buffer ref method to get a buffer reference instead of get a copy of the original buffer.

## Related issue number


## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
