### PR TITLE
[C++] Improve FormatTimePoint by removing sstream

### DIFF
--- a/src/fury/util/time_util.cc
+++ b/src/fury/util/time_util.cc
@@ -16,9 +16,8 @@
 
 #include "fury/util/time_util.h"
 #include <chrono>
+#include <cstdio>
 #include <ctime>
-#include <iomanip>
-#include <sstream>
 #include <string>
 
 namespace fury {
@@ -26,24 +25,21 @@ namespace fury {
 using std::chrono::system_clock;
 
 std::string FormatTimePoint(system_clock::time_point tp) {
-  std::stringstream ss;
   time_t raw_time = system_clock::to_time_t(tp);
   // unnecessary to release tm, it's created by localtime and every thread will
   // have one.
-  struct tm *timeinfo = std::localtime(&raw_time);
-  char buffer[80];
-  std::strftime(buffer, 80, "%Y-%m-%d %H:%M:%S,", timeinfo);
-  ss << buffer;
+  tm *timeinfo = std::localtime(&raw_time);
+
+  char datetime_str[64] = {};
+  size_t written_size = std::strftime(datetime_str, sizeof(datetime_str),
+                                      "%Y-%m-%d %H:%M:%S,", timeinfo);
   std::chrono::milliseconds ms =
       std::chrono::duration_cast<std::chrono::milliseconds>(
           tp.time_since_epoch());
-  std::string milliseconds_str = std::to_string(ms.count() % 1000);
-  if (milliseconds_str.length() < 3) {
-    milliseconds_str =
-        std::string(3 - milliseconds_str.length(), '0') + milliseconds_str;
-  }
-  ss << milliseconds_str;
-  return ss.str();
+  std::snprintf(datetime_str + written_size,
+                sizeof(datetime_str) - written_size, "%03ld",
+                ms.count() % 1000);
+  return datetime_str;
 }
 
 } // namespace fury


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

In FormatTimePoint we don't need to use std::stringstream and even std::string.

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass, see [here](https://github.com/alipay/fury/blob/main/CONTRIBUTING.rst) for how to run them
